### PR TITLE
Fix incorrect unauthorised chat command errors

### DIFF
--- a/twitchio/abcs.py
+++ b/twitchio/abcs.py
@@ -40,10 +40,10 @@ class Messageable(metaclass=abc.ABCMeta):
         if content.startswith('.'):
             content = content.lstrip('.')
 
-        if content.startswith(self.__invalid__):
-            raise InvalidContent('UnAuthorised chat command for send. Use built in method(s).')
-        else:
-            content = original
+            if content.startswith(self.__invalid__):
+                raise InvalidContent('UnAuthorised chat command for send. Use built in method(s).')
+            else:
+                content = original
 
         content = content.replace('\n', ' ')
 


### PR DESCRIPTION
Prevent non-command messages starting with "invalid" command names from giving an error when trying to send

Previously sending a message with any of the following at the beginning would raise `twitchio.errors.InvalidContent: UnAuthorised chat command for send. Use built in method(s).`:
`('ban', 'unban', 'timeout', 'me', 'w', 'colour', 'color', 'mod', 'unmod', 'clear', 'subscribers', 'subscriberoff', 'slow', 'slowoff', 'r9k', 'r9koff', 'emoteonly', 'emoteonlyoff', 'host', 'unhost')`