### PR TITLE
Add a channel to the cache as it joins one

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -254,6 +254,7 @@ class WebsocketConnection:
         for entry in channels:
             channel = re.sub('[#\s]', '', entry).lower()
             await self._websocket.send(f'JOIN #{channel}\r\n')
+            self._channel_cache[channel] = {'channel': Channel(channel, self, self._http), 'bot': None}
 
     async def _listen(self):
         backoff = ExponentialBackoff()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [ ] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add a channel in cache when the bot joins it


* **What is the current behavior?** (You can also link to an open issue here)
As long as there is no activity in the channel, the bot can't send anything, even if it joined it, because the channel is not stored in cache yet 


* **What is the new behavior (if this is a feature change)?**
The channel is stored in cache as soon as the bot joins it


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A

* **Other information**:
N/A