### PR TITLE
Improve logic in commands extension core

### DIFF
--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -89,10 +89,9 @@ class Command:
                 try:
                     argument = parsed.pop(index)
                 except (KeyError, IndexError):
-                    if param.default is not param.empty:
-                        args.append(param.default)
-                    else:
+                    if param.default is param.empty:
                         raise MissingRequiredArguments(f'Missing required arguments in command: {self.name}()')
+                    args.append(param.default)
                 else:
                     argument = await self._convert_types(param, argument)
                     args.append(argument)

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -57,10 +57,10 @@ class Command:
 
         converter = param.annotation
         if converter is param.empty:
-            if param.default is not param.empty:
-                converter = str if param.default is None else type(param.default)
-            else:
+            if param.default in (param.empty, None):
                 converter = str
+            else:
+                converter = type(param.default)
 
         try:
             argument = converter(parsed)


### PR DESCRIPTION
Improves logic and clarity for
- Type conversion of command argument when no type annotation is specified
- Handling of default value for command positional or keyword argument

There should be no changes functionally.

- [X] Tests have been conducted on the PR
- [ ] Docs have been added / updated (Not Applicable)