### PR TITLE
Improve MissingRequiredArguments

### DIFF
--- a/docs/twitchio.commands.rst
+++ b/docs/twitchio.commands.rst
@@ -23,7 +23,7 @@ Errors
 
 .. autoexception:: twitchio.ext.commands.errors.CommandNotFound
 
-.. autoexception:: twitchio.ext.commands.errors.MissingRequiredArguments
+.. autoexception:: twitchio.ext.commands.errors.MissingRequiredArgument
 
 .. autoexception:: twitchio.ext.commands.errors.BadArgument
 

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -81,7 +81,7 @@ class Command:
             if instance:
                 next(iterator)
         except StopIteration:
-            raise MissingRequiredArguments(f'self or ctx is a required argument which is missing.')
+            raise CommandError(f'self or ctx is a required argument which is missing.')
 
         for _, param in iterator:
             index += 1
@@ -92,7 +92,7 @@ class Command:
                     if param.default is not param.empty:
                         args.append(param.default)
                     else:
-                        raise MissingRequiredArguments(f'Missing required arguments in command: {self.name}()')
+                        raise MissingRequiredArguments(param)
                 else:
                     argument = await self._convert_types(param, argument)
                     args.append(argument)
@@ -106,7 +106,7 @@ class Command:
                     rest = param.default
 
                 if not rest and param.default is not None:
-                    raise MissingRequiredArguments(f'Missing required arguments in commands: {self.name}()')
+                    raise MissingRequiredArguments(param)
 
                 rest = await self._convert_types(param, rest)
                 kwargs[param.name] = rest

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -92,7 +92,7 @@ class Command:
                     if param.default is not param.empty:
                         args.append(param.default)
                     else:
-                        raise MissingRequiredArguments(param)
+                        raise MissingRequiredArgument(param)
                 else:
                     argument = await self._convert_types(param, argument)
                     args.append(argument)
@@ -106,7 +106,7 @@ class Command:
                     rest = param.default
 
                 if not rest and param.default is not None:
-                    raise MissingRequiredArguments(param)
+                    raise MissingRequiredArgument(param)
 
                 rest = await self._convert_types(param, rest)
                 kwargs[param.name] = rest

--- a/twitchio/ext/commands/errors.py
+++ b/twitchio/ext/commands/errors.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-__all__ = ('CommandError', 'CommandNotFound', 'MissingRequiredArguments', 'BadArgument',)
+__all__ = ('CommandError', 'CommandNotFound', 'MissingRequiredArgument', 'BadArgument',)
 
 
 from twitchio.errors import TwitchIOBException
@@ -40,7 +40,7 @@ class CommandNotFound(CommandError):
     pass
 
 
-class MissingRequiredArguments(CommandError):
+class MissingRequiredArgument(CommandError):
     """Exception raised when a required argument is not passed to a command.
 
     Attributes

--- a/twitchio/ext/commands/errors.py
+++ b/twitchio/ext/commands/errors.py
@@ -41,7 +41,16 @@ class CommandNotFound(CommandError):
 
 
 class MissingRequiredArguments(CommandError):
-    """Exception raised when a required argument is not passed to a command."""
+    """Exception raised when a required argument is not passed to a command.
+
+    Attributes
+    ----------
+    param: :class:`inspect.Parameter`
+        The argument that is missing.
+    """
+    def __init__(self, param):
+        self.param = param
+        super().__init__(f'{param.name} is a required argument that is missing.')
 
 
 class BadArgument(CommandError):


### PR DESCRIPTION
`MissingRequiredArguments` is renamed to `MissingRequiredArgument` (breaking change).
`CommandError` is now raised instead of `MissingRequiredArgument(s)` when self or ctx is missing.
`MissingRequiredArgument` now has a `param` attribute with the missing argument's `inspect.Parameter`.
The message for MissingRequiredArgument has been changed to use the parameter name instead of the command name. The command name can still be obtained through the `Context` parameter in `event_command_error`.

- [X] Tests have been conducted on the PR
- [X] Docs have been added / updated