### PR TITLE
Fix passage of raw data

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -413,7 +413,7 @@ class WebsocketConnection:
             user = None
 
         try:
-            message = Message(author=user, content=content, channel=channel, raw_data=data, tags=tags)
+            message = Message(author=user, content=content, channel=channel, raw_data=raw, tags=tags)
         except (TypeError, KeyError):
             message = None
 
@@ -454,7 +454,7 @@ class WebsocketConnection:
             message.echo = True
             message.channel._echo = True
 
-            await self._dispatch('raw_data', data)
+            await self._dispatch('raw_data', raw)
             await self._dispatch('message', message)
 
         elif action == 'USERSTATE':


### PR DESCRIPTION
Properly use the complete raw data (instead of a subsection of raw data) when instantiating `Message` objects (Fixes #43) and dispatching raw data event for Echo-Messages (Fixes #44).

This fixes issues with expected behavior and should not be considered a breaking change.

- [X] Tests have been conducted on the PR
- [ ] Docs have been added / updated (Not Applicable)