### PR TITLE
Default to an empty dictionary for User.badges and User.tags

### DIFF
--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -179,14 +179,12 @@ class User:
         self.subscriber = self._tags.get('subscriber', None)
         self.turbo = self._tags.get('turbo', None)
 
+        self._badges = {}
         badges = self._tags.get('badges', None)
         if badges:
-            self._badges = {}
             for chunk in badges.split(','):
                 k, _, v = chunk.partition('/')
                 self._badges[k] = int(v)
-        else:
-            self._badges = None
 
         self._mod = self._tags.get('mod', 0) if self._tags else attrs.get('mod', 0)
 
@@ -247,10 +245,10 @@ class User:
         return self.subscriber
 
     @property
-    def badges(self) -> Optional[dict]:
+    def badges(self) -> dict:
         """The badges associated with the User.
 
-        Could be None if no Tags were received.
+        Could be an empty Dict if no Tags were received.
         """
         return self._badges
 

--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -170,7 +170,7 @@ class User:
         self._ws = ws
 
         if not self._tags:
-            self._tags = {'None': 'None'}
+            self._tags = {}
 
         self.display_name = self._tags.get('display-name', self._name)
         self._id = int(self._tags.get('user-id', 0))
@@ -258,7 +258,7 @@ class User:
     def tags(self) -> dict:
         """The Tags received for the User.
 
-        Could be a Dict containing None if no tags were received.
+        Could be an empty Dict if no tags were received.
         """
         return self._tags
 

--- a/twitchio/dataclasses.pyi
+++ b/twitchio/dataclasses.pyi
@@ -53,7 +53,7 @@ class User:
         self._colour: Optional[str]
         self.subscriber: Optional[str]
         self.turbo: Optional[str]
-        self._badges: Optional[dict]
+        self._badges: dict
         self._mod: int
 
     def name(self) -> str: ...
@@ -70,7 +70,7 @@ class User:
 
     def is_subscriber(self) -> bool: ...
 
-    def badges(self) -> Optional[dict]: ...
+    def badges(self) -> dict: ...
 
     def tags(self) -> dict: ...
 

--- a/twitchio/dataclasses.pyi
+++ b/twitchio/dataclasses.pyi
@@ -45,7 +45,7 @@ class User:
     def __init__(self, ws: WebsocketConnection, **attrs):
         self._name: Optional[str]
         self._channel: Union[Channel, str]
-        self._tags: Optional[dict]
+        self._tags: dict
         self._ws: WebsocketConnection
         self.display_name: str
         self._id: int


### PR DESCRIPTION
Change the default value of User.badges from `None` to `{}`
Change the default value of User.tags from `{'None': 'None'}` to `{}`

The is a breaking change for the values of User.badges and User.tags when no badges/tags are received.

- [X] Tests have been conducted on the PR
- [X] Docs have been added / updated