### PR TITLE
Add Client.get_follow

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -238,6 +238,36 @@ class Client:
             secret=secret,
         )
 
+    async def get_follow(self, from_id: Union[int, str], to_id: Union[int, str]):
+        """|coro|
+
+        Retrieves the follow relationship between two users, provided it exists.
+
+        Parameters
+        ------------
+        from_id: Union[int, str]
+            The user who is following.
+        to_id: Union[int, str]
+            The user being followed.
+
+        Returns
+        ---------
+        dict
+            Dict containing follow relationship data. Could be None if there is no follow relationship.
+
+        Raises
+        --------
+        HTTPException
+            Bad request while fetching follow relationship.
+        """
+
+        data = await self.http.get_follow(str(from_id), str(to_id))
+
+        try:
+            return data[0]
+        except IndexError:
+            pass
+
     async def get_followers(self, user_id: Union[int, str], *, count: bool=False):
         """|coro|
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -173,6 +173,10 @@ class HTTPSession:
 
         return await self.request('GET', '/users', params=params)
 
+    async def get_follow(self, from_id: str, to_id: str):
+        params = [('from_id', from_id), ('to_id', to_id)]
+        return await self.request('GET', '/users/follows', params=params)
+
     async def get_followers(self, user_id: str, *, count):
         params = [('to_id', user_id)]
         return await self.request('GET', '/users/follows', params=params, count=count)


### PR DESCRIPTION
Add `Client.get_follow` to allow for the ability to get a single follow relationship between two users.

- [X] Tests have been conducted on the PR
- [X] Docs have been added / updated