### PR TITLE
Added part channel functionality

### DIFF
--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -399,6 +399,18 @@ class Bot(Client):
         """
         await self._ws.join_channels(*channels)
 
+    async def part_channels(self, channels: Union[List[str], Tuple[str]]):
+        """|coro|
+
+        Part the specified channels.
+
+        Parameters
+        ------------
+        channels: Union[List[str], Tuple[str]]
+            The channels in either a list or tuple form to part.
+        """
+        await self._ws.part_channels(*channels)
+
     async def get_context(self, message, cls=None):
         """|coro|
 

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -93,7 +93,7 @@ class WebsocketConnection:
         self._channel_cache = {}
         self._initial_channels = attrs.get('initial_channels')
 
-        self.nick = attrs.get('nick')
+        self.nick = attrs.get('nick').lower()
         self.extra_listeners = {}
 
         self.modes = attrs.pop('modes', ("commands", "tags", "membership"))
@@ -543,7 +543,7 @@ class WebsocketConnection:
     async def join_action(self, channel: str, author: str, tags):
         log.debug('ACTION:: JOIN: %s', channel)
 
-        if author.lower() == self.nick.lower():
+        if author == self.nick:
             chan_ = Channel(name=channel, ws=self, http=self._http)
             user = User(author=author, channel=chan_, tags=tags, ws=self._websocket)
 
@@ -570,7 +570,7 @@ class WebsocketConnection:
     async def part_action(self, channel: str, author: str, tags):
         log.debug('ACTION:: PART: %s', channel)
 
-        if author.lower() == self.nick.lower():
+        if author == self.nick:
             self._channel_cache.pop(channel)
             self._channel_token -= 1
 

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -301,7 +301,7 @@ class WebsocketConnection:
         channel = re.sub('[#\s]', '', entry).lower()
 
         if channel not in self._channel_cache:
-            raise ClientError(f'Request to leave the "{channel}" channel failed. You are not in that channel.')
+            raise ClientError(f'Request to leave the channel "{channel}" failed.')
 
         await self._websocket.send(f'PART #{channel}\r\n')
 
@@ -311,7 +311,7 @@ class WebsocketConnection:
             await asyncio.wait_for(fut, timeout=10)
         except asyncio.TimeoutError:
             raise asyncio.TimeoutError(
-                f'Request to part the "{channel}" channel has timed out.')
+                f'Request to leave the channel "{channel}" has timed out.')
 
     async def _listen(self):
         backoff = ExponentialBackoff()


### PR DESCRIPTION
New feature allowing bots to part channels in the same way that they can join them now.

* **What is the current behavior?**
There is no way currently for a bot to leave channels.

* **Does this PR introduce a breaking change?**
Doesn't impact existing code.
