### PR TITLE
Update example to new cog format

### DIFF
--- a/examples/discord_integration.py
+++ b/examples/discord_integration.py
@@ -28,7 +28,7 @@ from discord.ext import commands as discord_commands
 from twitchio.ext import commands as commands
 
 
-class DiscordCog(commands.Bot):
+class DiscordCog(commands.Bot, discord_commands.Cog):
 
     def __init__(self, bot):
         # Discord bot instance


### PR DESCRIPTION
With the update on 02/23/2019 Danny reworked the cogs system, it seems like this example was never updated for this change.

I have now done the needed changes for this example to work correctly. It was simply just to inherit discord.ext.commands.Cog.