### PR TITLE
Fixed infinite loop bug in HTTPSession.request method (occurs when limit is None)

### DIFF
--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -74,14 +74,15 @@ class HTTPSession:
             to_get = limit - len(data)
             return str(to_get) if to_get < 100 else '100'
 
-        while not reached_limit():
-            if cursor is not None:
-                params.append(('after', cursor))
+        is_finished = False
+        while not is_finished:
+            if limit is not None:
+                if cursor is not None:
+                    params.append(('after', cursor))
 
-            params.append(('first', get_limit()))
+                params.append(('first', get_limit()))
 
             body, is_text = await self._request(method, url, params=params, headers=headers, **kwargs)
-
             if is_text:
                 return body
 
@@ -102,6 +103,8 @@ class HTTPSession:
             else:
                 if not cursor:
                     break
+
+            is_finished = reached_limit() if limit is not None else True
 
         return data
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [ ] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a bug in the ``HTTPSession.request`` method.

* **What is the current behavior?** (You can also link to an open issue here)
If the limit kwarg is ``None``, the function never returns a value; rather, it continues in an infinite loop since the value of ``reached_limit`` is always ``False``/``None``.

* **What is the new behavior (if this is a feature change)?**
Modified function to remove pagination if the ``limit`` is None. Therefore, if ``limit`` is None, the function retrieves the full data in one request and then returns it.