### PR TITLE
Requests paginated

### DIFF
--- a/twitchio/cooldowns.py
+++ b/twitchio/cooldowns.py
@@ -30,7 +30,7 @@ import time
 
 class RateBucket:
 
-    HTTPLIMIT = 30
+    HTTPLIMIT = 800
     IRCLIMIT = 20
     MODLIMIT = 100
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [~sorta ] Tests have been conducted on the PR
- [ N/A] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
-- Currently any users who call get_followers (and similar) will only receive 20 results since pagination was borked.  
-- Additionally, current http request ratelimit was set to 30 in cooldowns (default when bearer token is not provided)  


* **What is the new behavior (if this is a feature change)?**
-- Pagination was restored by patching `http.py` from an old commit | https://github.com/TwitchIO/TwitchIO/commit/9b071783e27e1eea8f047044bdb12154803cc873 
-- Added a guard to prevent breakage in the event that a "misguided" user specifies limit=0 with the intent of fetching all results (i.e., "no limit") 
-- Updated `cooldowns.py` to reflect higher rate limit since bearer tokens are now required and implemented -- verifiable at:  https://dev.twitch.tv/docs/api/guide#rate-limits


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No changes necessary.


* **Other information**:
Manual testing was conducted as follows:
-- Works for specific follower count (i.e. limit=200)
    -- Checked edge cases for limit =  0, 1, 99, 100, 101, 199, 200, 201 
    -- Checked edge case where limit > actual follower count (returns all followers, no breakage)
-- "Misguided" follower count works (i.e. limit=0) gives all results 
-- Works for userid with zero actual followers (e.g., uid=430581923)
-- Works for userid with small number of followers (e.g., nine for uid=31493705)
