### PR TITLE
fix ValueError.

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -405,7 +405,7 @@ class WebsocketConnection:
             tagdict = {}
             for tag in str(tags).split(";"):
                 t = tag.split("=")
-                if t[1].isnumeric():
+                if t[1].isdecimal():
                     t[1] = int(t[1])
                 tagdict[t[0]] = t[1]
             tags = tagdict


### PR DESCRIPTION
Solving the problem that sometimes Chinese character numbers cause type errors.


* **Please check if the PR fulfills these requirements**
- [ ] Tests have been conducted on the PR
- [ ] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix:

I checked and corrected the problem of several Chinese characters passing through the "innumeric()" method.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
nothing. ;/


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
nothing. ;/


* **Other information**:

Traceback (most recent call last):
  File "...\venv\lib\site-packages\twitchio\websocket.py", line 409, in process_data
    t[1] = int(t[1])
ValueError: invalid literal for int() with base 10: '參參壹'


Traceback (most recent call last):
  File "...\venv\lib\site-packages\twitchio\websocket.py", line 409, in process_data
    t[1] = int(t[1])
ValueError: invalid literal for int() with base 10: '三零陸七八'
