### PR TITLE
remove logging of token, client id, and client secret

### DIFF
--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -75,7 +75,7 @@ class HTTPSession:
             data = await resp.json()
             self.token = data['access_token']
             self._refresh_token = data.get('refresh_token', None)
-            logging.info("Invalid or no token found, generated new token: %s", self.token)
+            logging.info("Invalid or no token found, generated new token")
 
     async def request(self, method, url, *, params=None, limit=None, **kwargs):
         count = kwargs.pop('count', False)
@@ -93,7 +93,7 @@ class HTTPSession:
             headers['Client-ID'] = str(self.client_id)
 
         if self.client_secret and self.client_id and not self.token:
-            logging.info("No token passed, generating new token under client id {0} and client secret {1}")
+            logging.info("No token passed, generating new token using client id and secret")
             await self.generate_token()
 
         if self.token is not None:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests have been conducted on the PR
- [X] Docs probably don't need to be updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Removes the logging of the info that should be hidden in http.py

* **What is the current behavior?** (You can also link to an open issue here)
When http.generate_token() is called, if it successfully generate a token, it gets logged at a logging level of INFO
It also attempts to log the client_id AND client_secret, but doesn't actually because of the way the line is written.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It should not be a breaking change