### PR TITLE
Custom

### DIFF
--- a/twitchio/cooldowns.py
+++ b/twitchio/cooldowns.py
@@ -30,7 +30,7 @@ import time
 
 class RateBucket:
 
-    HTTPLIMIT = 30
+    HTTPLIMIT = 800
     IRCLIMIT = 20
     MODLIMIT = 100
 


### PR DESCRIPTION
`http.py`: `request()`   additions to **kwargs** and signature changes:
- Added support for `cursor` to resume pagination after a previous request has been made. This functionality can be used to reduce the volume of remote requests when evaluating `total` in an initial response. 
- Bumped `full_reply` from optional param into kwargs