### PR TITLE
Fix badges error, add User.prediction, add Channel.get_custom_rewards

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -549,13 +549,16 @@ class WebsocketConnection:
 
             self._channel_cache[channel] = {'channel': chan_, 'bot': user}
 
-            if self._pending_joins:
+            if channel in self._pending_joins:
                 self._pending_joins[channel].set_result(None)
                 self._pending_joins.pop(channel)
 
             self._channel_token += 1
 
-        cache = self._channel_cache[channel]['channel']._users
+        try:
+            cache = self._channel_cache[channel]['channel']._users
+        except KeyError as e:
+            raise ClientError("The \"nick\" value passed to the constructor does not match the user we are logged in as") from e
 
         try:
             user = cache[author.lower()]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests have been conducted on the PR
- [x] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Fixes issues with twitchs new prediction feature
- adds support for the new channel points endpoints


* **What is the current behavior?** (You can also link to an open issue here)
- ValueError is thrown when a user has the prediction badge(s)


* **What is the new behavior (if this is a feature change)?**
- User._badges are no longer casted to int
- created User.prediction, returns pink, blue, or None
- created Channel.get_custom_rewards
- created CustomReward and CustomRewardRedemption dataclasses


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
I have not been able to fully test these features, as i do not have affilate on twitch, which is required for all the above changed features. If someone with affilate could test these features that would be great

Fixes #120 