### PR TITLE
Fix is_mod and process_data, add created_at

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -33,7 +33,7 @@ from twitchio.http import HTTPSession
 
 
 User = namedtuple('User', ('id', 'login', 'display_name', 'type', 'broadcaster_type', 'description',
-                           'profile_image', 'offline_image', 'view_count'))
+                           'profile_image', 'offline_image', 'view_count', 'created_at'))
 Chatters = namedtuple('Chatters', ('count', 'all', 'broadcaster', 'vips', 'moderators', 'staff',
                                    'admins', 'global_mods', 'viewers'))
 

--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-__all__ = ('Message', 'Channel', 'User', 'Context', 'NoticeSubscription')
+__all__ = ('Message', 'Channel', 'User', 'Context', 'NoticeSubscription', 'ClearChat')
 
 
 import datetime
@@ -657,3 +657,28 @@ class CustomRewardRedemption:
         else:
             self.__init__(data['data'], self._http, self.reward if isinstance(self.reward, CustomReward) else None)
             return self
+
+class ClearChat: # Add class for event_ban
+    """
+    The Dataclass sent to `event_ban` events.
+    Attributes
+    ------------
+    channel : :class:`.Channel`
+        The channel associated with the subscription event.
+    user : :class:`.User`
+        The user associated with the subscription event.
+    tags : dict
+        The raw tags dict associated with the subscription event.
+    ban_duration : Optional[int]
+        Duration of the timeout, in seconds.Could be None if the ban is permanent.
+    """
+
+    def __init__(self, *, channel: Channel, user: User, tags: dict):
+        self.channel = channel
+        self.user = user
+
+        self.tags = tags
+
+        self.ban_duration = tags.get('ban-duration', None)
+        if self.ban_duration:
+            self.ban_duration = int(self.ban_duration)

--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -310,7 +310,7 @@ class User:
         """A boolean indicating whether the User is a moderator of the current channel."""
         if self._mod == 1:
             return True
-        if self.channel.name == self.display_name.lower():
+        if self.channel.name == self.name.lower():
             return True
         else:
             return False

--- a/twitchio/dataclasses.pyi
+++ b/twitchio/dataclasses.pyi
@@ -109,3 +109,11 @@ class NoticeSubscription:
         self.streak_months: Optional[int] = tags.get('msg-param-streak-months', None)
         self.sub_plan: str = tags['msg-param-sub-plan']
         self.sub_plan_name: str = tags['msg-param-sub-plan-name']
+
+class ClearChat:
+
+    def __init__(self, *, channel: Channel, user: User, tags: dict):
+        self.channel: Channel = channel
+        self.user: User = user
+        self.tags: dict = tags
+        self.ban_duration: Optional[int] = tags.get('ban-duration', None)

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -405,7 +405,7 @@ class WebsocketConnection:
             tagdict = {}
             for tag in str(tags).split(";"):
                 t = tag.split("=")
-                if t[1].isnumeric():
+                if t[1].isdecimal():
                     t[1] = int(t[1])
                 tagdict[t[0]] = t[1]
             tags = tagdict

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -540,6 +540,14 @@ class WebsocketConnection:
 
             await self._dispatch('mode', channel, user, mstatus)
 
+        elif action == 'CLEARCHAT': #新增 被ban事件
+            log.debug('ACTION:: CLEARCHAT')
+
+            user = User(author=content, channel=channel, tags=tags, ws=self._websocket)
+            notice = ClearChat(channel=channel, user=user, tags=tags)
+
+            await self._dispatch('clearchat', notice)
+
     async def join_action(self, channel: str, author: str, tags):
         log.debug('ACTION:: JOIN: %s', channel)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [ ] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fix two bugs in the `User.is_mod` and `WebsocketConnection.process_data` method, and add "created_at" to User's namedtuple.



* **What is the current behavior?** (You can also link to an open issue here)
`User.is_mod`:
If the streamer's username and display name do not match (e.g. display name is not English), false will be returned.
 `WebsocketConnection.process_data`:
Using isnumeric() does not correctly determine if a string is an Arabic number (e.g. Chinese numbers will also return true).
`created_at`:
The "created_at" tag could not be identified.


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
