### PR TITLE
Bumped version due to lock issue for Python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp>=3.3.0,<3.6.0
-websockets>=6.0,<7.0
+websockets>=8.0


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests have been conducted on the PR
- [X] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A bugfix where Websockets versions < 8 are not compatible with Python 3.9


* **What is the current behavior?** (You can also link to an open issue here)
```
future: <Task finished name='Task-1' coro=<WSConnection._connect() done, 
defined at C:\Users\Koi\Documents\GitHub\TwitchIO\twitchio\websocket.py:101> exception=TypeError("'Lock' object is not iterable")>
```


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)




* **Other information**:


I've tested on Python 3.6, 3.7, and 3.8 and the issue seems to be resolved. 
Below is the full error message:
```
PS C:\Users\Koi\Documents\GitHub\TwitchIO> py -3.9 .\thing.py
conn
Task exception was never retrieved
future: <Task finished name='Task-1' coro=<WSConnection._connect() done, defined at C:\Users\Koi\Documents\GitHub\TwitchIO\twitchio\websocket.py:101> exception=TypeError("'Lock' object is not iterable")>
Traceback (most recent call last):
  File "C:\Users\Koi\Documents\GitHub\TwitchIO\twitchio\websocket.py", line 127, in _connect
    await self.authenticate(self._initial_channels)
  File "C:\Users\Koi\Documents\GitHub\TwitchIO\twitchio\websocket.py", line 192, in authenticate
    await self.send(f'PASS {self._token}\r\n')
  File "C:\Users\Koi\Documents\GitHub\TwitchIO\twitchio\websocket.py", line 172, in send
    await self._websocket.send(message + "\r\n")
    yield from self.write_frame(True, OP_TEXT, data.encode('utf-8'))
  File "C:\Users\Koi\AppData\Local\Programs\Python\Python39\lib\site-packages\websockets\protocol.py", line 911, in write_frame
    with (yield from self._drain_lock):
TypeError: 'Lock' object is not iterable
```



