### PR TITLE
Fix for channel point rewards in pubsub

### DIFF
--- a/twitchio/ext/pubsub/models.py
+++ b/twitchio/ext/pubsub/models.py
@@ -137,11 +137,7 @@ class PubSubChannelPointsMessage(PubSubMessage):
         self.id: str = redemption["id"]
         self.user = PartialUser(client._http, redemption["user"]["id"], redemption["user"]["display_name"])
         self.reward = CustomReward(client._http, redemption["reward"], PartialUser(client._http, self.channel_id, None))
-        if "user_input" in redemption:
-            self.input: str = redemption["user_input"]
-        else:
-            self.input: str = ""
-
+        self.input = redemption.get("user_input")
         self.status: str = redemption["status"]
 
 

--- a/twitchio/ext/pubsub/topics.py
+++ b/twitchio/ext/pubsub/topics.py
@@ -84,7 +84,7 @@ class Topic(_topic):
 
 bits = _topic("channel-bits-events-v2.{0}", [int])
 bits_badge = _topic("channel-bits-badge-unlocks.{0}", [int])
-channel_points = _topic("channel-points-v1.{0}", [int])
+channel_points = _topic("channel-points-channel-v1.{0}", [int])
 channel_subscriptions = _topic("channel-subscribe-events-v1.{0}", [int])
 moderation_user_action = _topic("chat_moderator_actions.{0}.{1}", [int, int])
 whispers = _topic("whispers.{0}", [int])

--- a/twitchio/rewards.py
+++ b/twitchio/rewards.py
@@ -67,7 +67,7 @@ class CustomReward:
     def __init__(self, http: "TwitchHTTP", obj: dict, channel: "PartialUser"):
         self._http = http
         self._channel = channel
-        self._broadcaster_id = obj["broadcaster_id"]
+        self._broadcaster_id = obj["channel_id"]
 
         self.id = obj["id"]
         self.image = obj["image"]["url_1x"] if obj["image"] else obj["default_image"]["url_1x"]
@@ -78,18 +78,18 @@ class CustomReward:
         self.prompt = obj["prompt"]
         self.input_required = obj["is_user_input_required"]
         self.max_per_stream = (
-            obj["max_per_stream_setting"]["is_enabled"],
-            obj["max_per_stream_setting"]["max_per_stream"],
+            obj["max_per_stream"]["is_enabled"],
+            obj["max_per_stream"]["max_per_stream"],
         )
         self.max_per_user_stream = (
-            obj["max_per_user_per_stream_setting"]["is_enabled"],
-            obj["max_per_user_per_stream_setting"]["max_per_user_per_stream"],
+            obj["max_per_user_per_stream"]["is_enabled"],
+            obj["max_per_user_per_stream"]["max_per_user_per_stream"],
         )
         self.cooldown = (
-            obj["global_cooldown_setting"]["is_enabled"],
-            obj["global_cooldown_setting"]["global_cooldown_seconds"],
+            obj["global_cooldown"]["is_enabled"],
+            obj["global_cooldown"]["global_cooldown_seconds"],
         )
-        self.paused = obj["paused"]
+        self.paused = obj["is_paused"]
         self.in_stock = obj["is_in_stock"]
         self.redemptions_skip_queue = obj["should_redemptions_skip_request_queue"]
         self.redemptions_current_stream = obj["redemptions_redeemed_current_stream"]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [ ] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix for PubSub not being able to process Channel Point Reward messages


* **What is the current behavior?** (You can also link to an open issue here)
bot will err out on a KeyError, has problems parsing the date and does expect different fields than returned from the API

```
  File "...\src\twitchio\twitchio\ext\pubsub\models.py", line 132, in __init__
    self.timestamp = datetime.datetime.strptime(data["redemption"]["redeemed_at"], "%Y-%m-%dT%H:%M:%SZ")
KeyError: 'redemption'
```

* **What is the new behavior (if this is a feature change)?**
n/a


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
n/a

