### PR TITLE
test wrapped function object when adding cog event

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -171,7 +171,7 @@ class Client:
                     future.set_result(args)
 
     def add_event(self, callback: Callable, name: str = None) -> None:
-        if not inspect.iscoroutine(callback) and not inspect.iscoroutinefunction(callback):
+        if not inspect.iscoroutine(callback) and not inspect.iscoroutinefunction(callback.func):
             raise ValueError("callback must be a coroutine")
 
         event_name = name or callback.__name__


### PR DESCRIPTION
iscoroutinefunction does not unwrap partial function objects in python < 3.8

* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [x] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix for #179 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

nope

* **Other information**:

found [this](https://stackoverflow.com/a/52422903)
> Using Python versions < 3.8 you can't make a partial() object pass that test, because the test requires there to be a `__code__` object attached directly to the object you pass to inspect.iscoroutinefunction(). You should instead test the function object that partial wraps, accessible via the partial.func attribute