### PR TITLE
Additional methods + fix remove_cog

### DIFF
--- a/twitchio/abcs.py
+++ b/twitchio/abcs.py
@@ -42,11 +42,7 @@ class IRCLimiterMapping:
 
         if bucket.method != method:
             bucket.method = method
-            if method == "mod":
-                bucket.limit = bucket.MODLIMIT
-            else:
-                bucket.limit = bucket.IRCLIMIT
-
+            bucket.limit = bucket.MODLIMIT if method == "mod" else bucket.IRCLIMIT
             self.buckets[channel] = bucket
 
         return bucket

--- a/twitchio/chatter.py
+++ b/twitchio/chatter.py
@@ -160,10 +160,7 @@ class Chatter(PartialChatter):
         """A boolean indicating whether the User is a moderator of the current channel."""
         if self._mod == 1:
             return True
-        if self.channel.name == self.display_name.lower():
-            return True
-        else:
-            return False
+        return self.channel.name == self.display_name.lower()
 
     @property
     def is_turbo(self) -> Optional[bool]:

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -287,6 +287,26 @@ class Client:
 
             return Channel(name=name, websocket=self._connection)
 
+    async def fetch_channel(self, broadcaster: str) -> list:
+        """Retrieve a channel from the API.
+
+        Parameters
+        -----------
+        name: str
+            The channel name or ID to request from API. Returns empty list if no channel was found.
+
+        Returns
+        --------
+            :class:`list`
+        """
+
+        if not broadcaster.isdigit():
+            get_id : User = await self.fetch_users(names=[broadcaster.lower()])
+            for i in get_id:
+                broadcaster = i.id
+
+        return await self._http.get_channels(broadcaster)
+
     async def join_channels(self, channels: Union[List[str], Tuple[str]]):
         """|coro|
 

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -83,7 +83,11 @@ class Client:
 
         self._http = TwitchHTTP(self, api_token=token, client_secret=client_secret)
         self._connection = WSConnection(
-            client=self, token=token, loop=self.loop, initial_channels=initial_channels, heartbeat=heartbeat
+            client=self,
+            token=token,
+            loop=self.loop,
+            initial_channels=initial_channels,
+            heartbeat=heartbeat,
         )
 
         self._events = {}
@@ -127,7 +131,10 @@ class Client:
         self._http = TwitchHTTP(self, client_id=client_id, client_secret=client_secret)
         self._heartbeat = heartbeat
         self._connection = WSConnection(
-            client=self, loop=self.loop, initial_channels=None, heartbeat=self._heartbeat
+            client=self,
+            loop=self.loop,
+            initial_channels=None,
+            heartbeat=self._heartbeat,
         )  # The only reason we're even creating this is to avoid attribute errors
         self._events = {}
         self._waiting = []
@@ -192,7 +199,10 @@ class Client:
             if inspect.iscoroutinefunction(inner_cb):
                 self.loop.create_task(wrapped(inner_cb))
             else:
-                warnings.warn(f"event '{name}' callback is not a coroutine", category=RuntimeWarning)
+                warnings.warn(
+                    f"event '{name}' callback is not a coroutine",
+                    category=RuntimeWarning,
+                )
 
         if name in self._events:
             for event in self._events[name]:
@@ -239,7 +249,11 @@ class Client:
         return decorator
 
     async def wait_for(
-        self, event: str, predicate: Callable[[], bool] = lambda *a: True, *, timeout=60.0
+        self,
+        event: str,
+        predicate: Callable[[], bool] = lambda *a: True,
+        *,
+        timeout=60.0,
     ) -> Tuple[Any]:
         """|coro|
 
@@ -301,7 +315,7 @@ class Client:
         """
 
         if not broadcaster.isdigit():
-            get_id : User = await self.fetch_users(names=[broadcaster.lower()])
+            get_id: User = await self.fetch_users(names=[broadcaster.lower()])
             for i in get_id:
                 broadcaster = i.id
 
@@ -353,7 +367,11 @@ class Client:
 
     @user_cache()
     async def fetch_users(
-        self, names: List[str] = None, ids: List[int] = None, token: str = None, force=False
+        self,
+        names: List[str] = None,
+        ids: List[int] = None,
+        token: str = None,
+        force=False,
     ) -> List[User]:
         """|coro|
         Fetches users from the helix API
@@ -438,7 +456,13 @@ class Client:
         from .models import Video
 
         data = await self._http.get_videos(
-            ids, user_id=user_id, game_id=game_id, period=period, sort=sort, type=type, language=language
+            ids,
+            user_id=user_id,
+            game_id=game_id,
+            period=period,
+            sort=sort,
+            type=type,
+            language=language,
         )
         return [Video(self._http, x) for x in data]
 
@@ -470,7 +494,9 @@ class Client:
         data = await self._http.get_top_games()
         return [models.Game(d) for d in data]
 
-    async def fetch_games(self, ids: List[int] = None, names: List[str] = None) -> List[models.Game]:
+    async def fetch_games(
+        self, ids: List[int] = None, names: List[str] = None
+    ) -> List[models.Game]:
         """|coro|
         Fetches games by id or name.
         At least one id or name must be provided
@@ -750,7 +776,9 @@ class Client:
             async def event_error(error, data):
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
         """
-        traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+        traceback.print_exception(
+            type(error), error, error.__traceback__, file=sys.stderr
+        )
 
     async def event_ready(self):
         """|coro|

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -316,8 +316,7 @@ class Client:
 
         if not broadcaster.isdigit():
             get_id = await self.fetch_users(names=[broadcaster.lower()])
-            for i in get_id:
-                broadcaster = i.id
+            broadcaster = get_id[0].id
 
         return await self._http.get_channels(broadcaster)
 
@@ -465,6 +464,33 @@ class Client:
             language=language,
         )
         return [Video(self._http, x) for x in data]
+
+    async def fetch_follow(self, from_id: str, to_id: str, token: str = None):
+        """|coro|
+        Check if a user follows another user or when they followed a user.
+
+        Parameters
+        -----------
+        token: Optional[:class:`str`]
+            An oauth token to use instead of the bots token
+
+        Returns
+        --------
+            List[:class:`twitchio.FollowEvent`]
+        """
+
+        if not from_id.isdigit():
+            get_id = await self.fetch_users(names=[from_id.lower()])
+            from_id = get_id[0].id
+
+        if not to_id.isdigit():
+            get_id = await self.fetch_users(names=[to_id.lower()])
+            to_id = get_id[0].id
+
+        from .models import FollowEvent
+
+        data = await self._http.get_user_follows(from_id=str(from_id), to_id=str(to_id))
+        return [FollowEvent(self._http, d) for d in data]
 
     async def fetch_cheermotes(self, user_id: int = None):
         """|coro|

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -315,7 +315,7 @@ class Client:
         """
 
         if not broadcaster.isdigit():
-            get_id: User = await self.fetch_users(names=[broadcaster.lower()])
+            get_id = await self.fetch_users(names=[broadcaster.lower()])
             for i in get_id:
                 broadcaster = i.id
 

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -285,8 +285,7 @@ class Client:
             # With the associated users as a set.
             # We create a Channel here and return it only if the cache has that channel key.
 
-            channel = Channel(name=name, websocket=self._connection)
-            return channel
+            return Channel(name=name, websocket=self._connection)
 
     async def join_channels(self, channels: Union[List[str], Tuple[str]]):
         """|coro|

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -192,9 +192,7 @@ class Bot(Client):
         ---------
         Optional[:class:`.Cog`]
         """
-        cog = self.cogs.get(name, None)
-
-        return cog
+        return self.cogs.get(name, None)
 
     async def get_context(self, message, *, cls=None):
         """Get a Context object from a message.

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -366,7 +366,7 @@ class Bot(Client):
         cog._load_methods(self)
         self._cogs[cog.name] = cog
 
-    def remove_cog(self, cog_name: str):
+    def remove_cog(self, cog: Cog):
         """Method which removes a cog from the bot.
 
         Parameters
@@ -374,10 +374,10 @@ class Bot(Client):
         cog_name: str
             The name of the cog to remove.
         """
-        if cog_name not in self._cogs:
-            raise InvalidCog(f"Cog '{cog_name}' not found")
+        if cog.name not in self._cogs:
+            raise InvalidCog(f"Cog '{cog.name}' not found")
 
-        cog = self._cogs.pop(cog_name)
+        cog = self._cogs.pop(cog.name)
 
         cog._unload_methods(self)
 

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -102,9 +102,12 @@ class Command:
         return f"{self.parent.full_name} {self._name}"
 
     def _resolve_converter(self, converter: Union[Callable, Awaitable, type]) -> Callable:
-        if isinstance(converter, type) and converter.__module__.startswith("twitchio"):
-            if converter in builtin_converter._mapping:
-                return builtin_converter._mapping[converter]
+        if (
+            isinstance(converter, type)
+            and converter.__module__.startswith("twitchio")
+            and converter in builtin_converter._mapping
+        ):
+            return builtin_converter._mapping[converter]
 
         return converter
 
@@ -277,9 +280,8 @@ class Command:
                 if not result:
                     raise CheckFailure(f"The check {predicate} for command {self.name} failed.")
 
-            if self.cog:
-                if not await self.cog.cog_check(context):
-                    raise CheckFailure(f"The cog check for command <{self.name}> failed.")
+            if self.cog and not await self.cog.cog_check(context):
+                raise CheckFailure(f"The cog check for command <{self.name}> failed.")
 
             return True
         except Exception as e:
@@ -457,9 +459,12 @@ def command(
 
     def decorator(func: Callable):
         fname = name or func.__name__
-        cmd = cls(name=fname, func=func, aliases=aliases, no_global_checks=no_global_checks)
-
-        return cmd
+        return cls(
+            name=fname,
+            func=func,
+            aliases=aliases,
+            no_global_checks=no_global_checks,
+        )
 
     return decorator
 
@@ -477,15 +482,13 @@ def group(
 
     def decorator(func: Callable):
         fname = name or func.__name__
-        cmd = cls(
+        return cls(
             name=fname,
             func=func,
             aliases=aliases,
             no_global_checks=no_global_checks,
             invoke_with_subcommand=invoke_with_subcommand,
         )
-
-        return cmd
 
     return decorator
 

--- a/twitchio/ext/commands/meta.py
+++ b/twitchio/ext/commands/meta.py
@@ -47,9 +47,10 @@ class CogMeta(type):
         self._commands = {}
 
         for name, mem in inspect.getmembers(self):
-            if isinstance(mem, (CogEvent, Command)):
-                if name.startswith(("cog_", "bot_")):  # Invalid method prefixes
-                    raise RuntimeError(f'The event or command "{name}" starts with an invalid prefix (cog_ or bot_).')
+            if isinstance(mem, (CogEvent, Command)) and name.startswith(
+                ("cog_", "bot_")
+            ):  # Invalid method prefixes
+                raise RuntimeError(f'The event or command "{name}" starts with an invalid prefix (cog_ or bot_).')
 
             if isinstance(mem, CogEvent):
                 try:

--- a/twitchio/ext/pubsub/pool.py
+++ b/twitchio/ext/pubsub/pool.py
@@ -87,17 +87,16 @@ class PubSubPool:
                 self._pool.remove(node)
 
     def _find_node(self, topics: List[Topic]) -> Optional[PubSubWebsocket]:
-        if self._mode == "group":
-            for p in self._pool:
-                if len(p.max_topics) + len(topics) <= p.max_topics:
-                    return p
-
-            if len(self._pool) < self._max_size:
-                return None
-            else:
-                raise models.PoolFull(
-                    f"The pubsub pool has reached maximum topics. Unable to allocate a group of {len(topics)} topics."
-                )
-
-        else:
+        if self._mode != "group":
             raise ValueError("group is the only supported mode.")
+
+        for p in self._pool:
+            if len(p.max_topics) + len(topics) <= p.max_topics:
+                return p
+
+        if len(self._pool) < self._max_size:
+            return None
+        else:
+            raise models.PoolFull(
+                f"The pubsub pool has reached maximum topics. Unable to allocate a group of {len(topics)} topics."
+            )

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -134,7 +134,7 @@ class PubSubWebsocket:
         await self._send_topics(topics)
 
     async def unsubscribe_topic(self, topics: List[Topic]):
-        if not all([t in self.topics for t in topics]):
+        if any(t not in self.topics for t in topics):
             raise ValueError("Topics were given that have not been subscribed to")
 
         await self._send_topics(topics, type="UNLISTEN")

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -284,7 +284,7 @@ class TwitchHTTP:
             self.session = aiohttp.ClientSession()
 
         async with self.session.post(url) as resp:
-            if 300 < resp.status or resp.status < 200:
+            if resp.status > 300 or resp.status < 200:
                 raise errors.HTTPException("Unable to generate a token: " + await resp.text())
 
             data = await resp.json()
@@ -305,7 +305,7 @@ class TwitchHTTP:
             if resp.status == 401:
                 raise errors.AuthenticationError("Invalid or unauthorized Access Token passed.")
 
-            if 300 < resp.status or resp.status < 200:
+            if resp.status > 300 or resp.status < 200:
                 raise errors.HTTPException("Unable to validate Access Token: " + await resp.text())
 
             data: dict = await resp.json()
@@ -317,7 +317,7 @@ class TwitchHTTP:
         return data
 
     async def post_commercial(self, token: str, broadcaster_id: str, length: int):
-        assert length in (30, 60, 90, 120, 150, 180)
+        assert length in {30, 60, 90, 120, 150, 180}
         data = await self.request(
             Route(
                 "POST", "channels/commercial", body={"broadcaster_id": broadcaster_id, "length": length}, token=token
@@ -351,7 +351,7 @@ class TwitchHTTP:
     async def get_bits_board(
         self, token: str, period: str = "all", user_id: str = None, started_at: datetime.datetime = None
     ):
-        assert period in ("all", "day", "week", "month", "year")
+        assert period in {"all", "day", "week", "month", "year"}
         route = Route(
             "GET",
             "bits/leaderboard",

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -80,5 +80,4 @@ class Message:
         timestamp:
             UTC datetime object of the Twitch timestamp.
         """
-        timestamp = datetime.datetime.utcfromtimestamp(int(self._timestamp) / 1000)
-        return timestamp
+        return datetime.datetime.utcfromtimestamp(int(self._timestamp) / 1000)

--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -551,7 +551,7 @@ class Stream:
 
     def __init__(self, http: "TwitchHTTP", data: dict):
         self.id: int = data["id"]
-        self.user = PartialUser(http, data["user_id"], data["user_name"], data["user_login"])
+        self.user = PartialUser(http, data["user_id"], data["user_name"])
         self.game_id: int = data["game_id"]
         self.game_name: str = data["game_name"]
         self.type: str = data["type"]

--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -280,7 +280,7 @@ class Marker:
         self.created_at = datetime.datetime.strptime(data["created_at"], "%Y-%m-%dT%H:%M:%SZ")
         self.description: str = data["description"]
         self.position: int = data["position_seconds"]
-        self.url: Optional[str] = data.get("URL", None)
+        self.url: Optional[str] = data.get("URL")
 
     def __repr__(self):
         return f"<Marker id={self.id} created_at={self.created_at} position={self.position} url={self.url}>"

--- a/twitchio/parse.py
+++ b/twitchio/parse.py
@@ -38,11 +38,7 @@ TMI = "tmi.twitch.tv"
 
 def parser(data: str, nick: str):
     groups = data.split()
-    if groups[1] == "JOIN":
-        action = groups[1]
-    else:
-        action = groups[-2]
-
+    action = groups[1] if groups[1] == "JOIN" else groups[-2]
     channel = None
     message = None
     user = None
@@ -51,7 +47,7 @@ def parser(data: str, nick: str):
     if action == "PING":
         return dict(action="PING")
 
-    elif groups[2] == "PRIVMSG" or groups[2] == "PRIVMSG(ECHO)":
+    elif groups[2] in ["PRIVMSG", "PRIVMSG(ECHO)"]:
         action = groups[2]
         channel = groups[3].lstrip("#")
         message = " ".join(groups[4:]).lstrip(":")
@@ -134,6 +130,3 @@ def parse(data: str, ws: "WSConnection"):
         msg = msg.replace(":tmi.twitch.tv ", "")
         groups = msg.split()
         length = len(groups)
-
-        if length > 2 and groups[1] == "JOIN":
-            pass

--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -153,9 +153,12 @@ class PartialUser:
         -------
 
         """
-        if not force and self._cached_rewards:
-            if self._cached_rewards[0] + 300 > time.monotonic():
-                return self._cached_rewards[1]
+        if (
+            not force
+            and self._cached_rewards
+            and self._cached_rewards[0] + 300 > time.monotonic()
+        ):
+            return self._cached_rewards[1]
 
         try:
             data = await self._http.get_rewards(token, self.id, only_manageable, ids)
@@ -653,7 +656,7 @@ class User(PartialUser):
         self.profile_image = data["profile_image_url"]
         self.offline_image = data["offline_image_url"]
         self.view_count = (data["view_count"],)
-        self.email = data.get("email", None)
+        self.email = data.get("email")
 
     def __repr__(self):
         return f"<User id={self.id} name={self.name} display_name={self.display_name} type={self.type}>"

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -330,10 +330,10 @@ class WSConnection:
                 self.is_ready.set()
             else:
                 self._cache_add(parsed)
-        else:
-            if self.is_ready.is_set():
-                return
+        elif self.is_ready.is_set():
+            return
 
+        else:
             self.is_ready.set()
             # self.dispatch("ready")
 
@@ -344,7 +344,6 @@ class WSConnection:
 
     async def _part(self, parsed):  # TODO
         log.debug(f'ACTION: PART:: {parsed["channel"]}')
-        pass
 
     async def _privmsg(self, parsed):  # TODO(Update Cache properly)
         log.debug(f'ACTION: PRIVMSG:: {parsed["channel"]}')
@@ -392,7 +391,6 @@ class WSConnection:
 
     async def _usernotice(self, parsed):  # TODO
         log.debug(f'ACTION: USERNOTICE:: {parsed["channel"]}')
-        pass
 
     async def _join(self, parsed):
         log.debug(f'ACTION: JOIN:: {parsed["channel"]}')
@@ -406,7 +404,7 @@ class WSConnection:
             else:
                 self._join_pending.pop(channel)
 
-        if not parsed["user"] == self._client.nick:
+        if parsed["user"] != self._client.nick:
             self._cache_add(parsed)
 
         channel = Channel(name=channel, websocket=self)


### PR DESCRIPTION
Added `fetch_follow` to client method to compare any 2 users relationship (from 1.2.3 missing from 2.0)
Can use ID or name

Added` fetch_channel` to client
You can now fetch the data for any channel without using private _http private methods using ID or name

REMOVE_COGS CAN BE IGNORED I FOUND FURTHER ISSUES

Tided up some general code