### PR TITLE
Update channel join rate limit

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -70,7 +70,7 @@ class WSConnection:
         self.is_ready: asyncio.Event = asyncio.Event()
         self._join_lock: asyncio.Lock = asyncio.Lock()
         self._join_handle = 0
-        self._join_tick = 50
+        self._join_tick = 20
         self._join_pending = {}
         self._join_load = {}
         self._init = False
@@ -243,8 +243,8 @@ class WSConnection:
         async with self._join_lock:  # acquire a lock, allowing only one join_channels at once...
             for channel in channels:
                 if self._join_handle < time.time():  # Handle is less than the current time
-                    self._join_tick = 50  # So lets start a new rate limit bucket..
-                    self._join_handle = time.time() + 15  # Set the handle timeout time
+                    self._join_tick = 20  # So lets start a new rate limit bucket..
+                    self._join_handle = time.time() + 10  # Set the handle timeout time
 
                 if self._join_tick == 0:  # We have exhausted the bucket, wait so we can make a new one...
                     await asyncio.sleep(self._join_handle - time.time())


### PR DESCRIPTION
It is stated in the IRC guide that channel join rate limit is now 20 joins per 10 seconds. This fixes the old 50/15 to the new 20/10.

https://dev.twitch.tv/docs/irc/guide#rate-limits

I noticed this issue when trying to join 62 channels. Most of the channels would not be connected with the following traceback:

```python-traceback
The channel "[REDACTED]" was unable to be joined. Check the channel is valid.
Task exception was never retrieved
future: <Task finished name='Task-121' coro=<WSConnection._join_future_handle() done, defined at /usr/local/lib/python3.9/site-packages/twitchio/websocket.py:263> exception=ValueError('list.remove(x): x not in list')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 492, in wait_for
    fut.result()
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/twitchio/websocket.py", line 265, in _join_future_handle
    await asyncio.wait_for(fut, timeout=10)
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 494, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/twitchio/websocket.py", line 275, in _join_future_handle
    await self._process_data(data)
  File "/usr/local/lib/python3.9/site-packages/twitchio/websocket.py", line 284, in _process_data
    return await self._code(parsed, parsed["code"])
  File "/usr/local/lib/python3.9/site-packages/twitchio/websocket.py", line 321, in _code
    self._initial_channels.remove(parsed["batches"][0])
ValueError: list.remove(x): x not in list
```