### PR TITLE
Fix pubsub - unban request

### DIFF
--- a/twitchio/ext/pubsub/models.py
+++ b/twitchio/ext/pubsub/models.py
@@ -302,7 +302,6 @@ class PubSubModerationActionBanRequest(PubSubMessage):
             if data["message"]["data"]["target_user_id"]
             else None
         )
-        self.from_automod: bool = data["message"]["data"]["from_automod"]
 
 
 class PubSubModerationActionChannelTerms(PubSubMessage):


### PR DESCRIPTION
Problem: Unbanrequests dont have any automod in payload
To fix this I think its enough to remove line 305 in models.py (pubsub)
--> `self.from_automod: bool = data["message"]["data"]["from_automod"]`
more detailed in issue #189 
fixes #189 