### PR TITLE
fix typo in Channel.user()

### DIFF
--- a/twitchio/channel.py
+++ b/twitchio/channel.py
@@ -127,7 +127,7 @@ class Channel(Messageable):
         --------
         :class:`twitchio.User` the user associated with the channel
         """
-        return (await self._ws._client.fetch_users(login=[self._name], force=force))[0]
+        return (await self._ws._client.fetch_users(names=[self._name], force=force))[0]
 
     async def fetch_bits_leaderboard(
         self, token: str, period: str = "all", user_id: int = None, started_at: datetime.datetime = None


### PR DESCRIPTION
fix `user()` method that raises `TypeError: got an unexpected keyword argument 'login'`