### PR TITLE
Fixed get_custom_rewards()

### DIFF
--- a/twitchio/rewards.py
+++ b/twitchio/rewards.py
@@ -67,7 +67,7 @@ class CustomReward:
     def __init__(self, http: "TwitchHTTP", obj: dict, channel: "PartialUser"):
         self._http = http
         self._channel = channel
-        self._broadcaster_id = obj["channel_id"]
+        self._broadcaster_id = obj["broadcaster_id"]
 
         self.id = obj["id"]
         self.image = obj["image"]["url_1x"] if obj["image"] else obj["default_image"]["url_1x"]
@@ -78,16 +78,16 @@ class CustomReward:
         self.prompt = obj["prompt"]
         self.input_required = obj["is_user_input_required"]
         self.max_per_stream = (
-            obj["max_per_stream"]["is_enabled"],
-            obj["max_per_stream"]["max_per_stream"],
+            obj["max_per_stream_setting"]["is_enabled"],
+            obj["max_per_stream_setting"]["max_per_stream"],
         )
         self.max_per_user_stream = (
-            obj["max_per_user_per_stream"]["is_enabled"],
-            obj["max_per_user_per_stream"]["max_per_user_per_stream"],
+            obj["max_per_user_per_stream_setting"]["is_enabled"],
+            obj["max_per_user_per_stream_setting"]["max_per_user_per_stream"],
         )
         self.cooldown = (
-            obj["global_cooldown"]["is_enabled"],
-            obj["global_cooldown"]["global_cooldown_seconds"],
+            obj["global_cooldown_setting"]["is_enabled"],
+            obj["global_cooldown_setting"]["global_cooldown_seconds"],
         )
         self.paused = obj["is_paused"]
         self.in_stock = obj["is_in_stock"]

--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -855,6 +855,7 @@ class User(PartialUser):
         self.view_count = (data["view_count"],)
         self.created_at = data["created_at"]
         self.email = data.get("email")
+        self._cached_rewards = None
 
     def __repr__(self):
         return f"<User id={self.id} name={self.name} display_name={self.display_name} type={self.type}>"


### PR DESCRIPTION
https://github.com/TwitchIO/TwitchIO/issues/214

Twitch updated the json keys for custom rewards.
User doesn't have an attribute _cached_rewards.

Plz don't laugh at me, if something is wrong, its my first PR :D 