### PR TITLE
fix unsubscribe_topics() typo

### DIFF
--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -133,7 +133,7 @@ class PubSubWebsocket:
 
         await self._send_topics(topics)
 
-    async def unsubscribe_topic(self, topics: List[Topic]):
+    async def unsubscribe_topics(self, topics: List[Topic]):
         if any(t not in self.topics for t in topics):
             raise ValueError("Topics were given that have not been subscribed to")
 


### PR DESCRIPTION
This PR intends to fix a typo I was running into when calling [`PubSubPool#unsubscribe_topics()`](https://github.com/charlesmadere/CynanBot/blob/975131622e7aad00bccdff15bf4217ff099cd0b4/cynanBot.py#L508).

This is my first PR against this repository, sorry if there is more procedure I need to be following in order to make a PR. If there's anything more I need to do, please let me know.