### PR TITLE
add support for the client to be able to handle pubsub errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@
 
 - ext.pubsub
     - Fixed bug with Pool.unsubscribe_topics caused by typo
+    - Added :func:`ext.pubsub.Websocket.pubsub_error` to support being notified of pubsub errors
+    - Added :func:`ext.pubsub.Websocket.pubsub_nonce` to support being notified of pubsub nonces
 
 - ext.eventsub
     - fix :class:`ext.eventsub.models.ChannelBanData`'s ``permanent`` attribute accessing nonexistent attrs from the event payload

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -193,5 +193,7 @@ class PubSubWebsocket:
     async def handle_response(self, message: dict):
         if message["error"]:
             logger.error(f"Recieved errored response for nonce {message['nonce']}: {message['error']}")
+            self.client.run_event("pubsub_error", message)
         elif message["nonce"]:
             logger.debug(f"Recieved OK response for nonce {message['nonce']}")
+            self.client.run_event("pubsub_nonce", message)

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -192,8 +192,8 @@ class PubSubWebsocket:
 
     async def handle_response(self, message: dict):
         if message["error"]:
-            logger.error(f"Recieved errored response for nonce {message['nonce']}: {message['error']}")
+            logger.error(f"Received errored response for nonce {message['nonce']}: {message['error']}")
             self.client.run_event("pubsub_error", message)
         elif message["nonce"]:
-            logger.debug(f"Recieved OK response for nonce {message['nonce']}")
+            logger.debug(f"Received OK response for nonce {message['nonce']}")
             self.client.run_event("pubsub_nonce", message)


### PR DESCRIPTION
As far as I know, without these changes, it is impossible for a client to properly handle and/or react to pubsub errors. For example, they may need to refresh their Twitch token.