### PR TITLE
fix unsubscribe_topics() typo

### DIFF
--- a/twitchio/ext/pubsub/pool.py
+++ b/twitchio/ext/pubsub/pool.py
@@ -81,7 +81,7 @@ class PubSubPool:
 
         """
         for node, vals in itertools.groupby(topics, lambda t: self._topics[t]):
-            await node.unsubscribe_topics(vals)
+            await node.unsubscribe_topic(vals)
             if not node.topics:
                 await node.disconnect()
                 self._pool.remove(node)


### PR DESCRIPTION
The `PubSubPool` class has a typo where it tries to call `PubSubWebsocket#unsubscribe_topics()`, which does not exist (the method is actually called `PubSubWebsocket#unsubscribe_topic()`).

I tried to fix this in #219, but that could be a breaking change, and as such, this PR here should fix this in a non-breaking way.