### PR TITLE
bug fix user.py modify_stream() v2

### DIFF
--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -740,10 +740,13 @@ class PartialUser:
         title: :class:`str`
             Optional title of the stream.
         """
+        if game_id is not None:
+            game_id = str(game_id)
+
         await self._http.patch_channel(
             token,
             broadcaster_id=str(self.id),
-            game_id=str(game_id),
+            game_id=game_id,
             language=language,
             title=title,
         )


### PR DESCRIPTION
Fixed bug in function modify_stream().
game_id changed from int to str.
If no game_id was given, the error code 400 occurred because None was formatted into a string.

Bug fix has been tested and works.