### PR TITLE
Fix is_subscriber for founder

### DIFF
--- a/twitchio/chatter.py
+++ b/twitchio/chatter.py
@@ -203,7 +203,7 @@ class Chatter(PartialChatter):
 
             changed in 2.1.0: return value is no longer optional. founders will now appear as subscribers
         """
-        return bool(self._sub) if self._sub is not None else "founder" in self.badges
+        return bool(self._sub) or "founder" in self.badges
 
     @property
     def prediction(self) -> Optional[PredictionEnum]:


### PR DESCRIPTION
else clause in expression was never getting executed due to int(0) being returned rather than None.

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)