### PR TITLE
Close http session when bot closes.

### DIFF
--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -483,5 +483,8 @@ class WSConnection:
         for fut in futures:
             fut.cancel()
 
-        await self._websocket.close()
+        if self._websocket:
+            await self._websocket.close()
+        if self._client._http.session:
+            await self._client._http.session.close()
         self._loop.stop()


### PR DESCRIPTION
## Pull request summary

This fixes an asyncio error about an unclosed session (eventually resulting in an attribute error).

```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x0000023BE9D55040>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x0000023BE934B460>, 511380.203)]']
connector: <aiohttp.connector.TCPConnector object at 0x0000023BE9D55610>
Fatal error on SSL transport
protocol: <asyncio.sslproto.SSLProtocol object at 0x0000023BE87CCF40>
transport: <_ProactorSocketTransport fd=-1 read=<_OverlappedFuture cancelled>>
Traceback (most recent call last):
  File "D:\programs\Python39\lib\asyncio\sslproto.py", line 684, in _process_write_backlog
    self._transport.write(chunk)
  File "D:\programs\Python39\lib\asyncio\proactor_events.py", line 359, in write
    self._loop_writing(data=bytes(data))
  File "D:\programs\Python39\lib\asyncio\proactor_events.py", line 395, in _loop_writing
    self._write_fut = self._loop._proactor.send(self._sock, data)
AttributeError: 'NoneType' object has no attribute 'send'
```

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)