### PR TITLE
Fix for RuntimeError('Event loop is closed')

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -153,7 +153,6 @@ class Client:
             pass
         finally:
             self.loop.run_until_complete(self.close())
-            self.loop.close()
 
     async def start(self):
         """|coro|


### PR DESCRIPTION
## Pull request summary

As noted in #247, when exiting the bot, a runtime error is given. This appears to be caused by the run function explicitly closing the event loop, whilst some background tasks are still running on the event loop.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)