### PR TITLE
Python 3.10 compatibility, drop loop= for >=3.10

### DIFF
--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -24,7 +24,6 @@ DEALINGS IN THE SOFTWARE.
 
 import asyncio
 import logging
-import sys
 import time
 import uuid
 from itertools import groupby
@@ -73,10 +72,7 @@ class PubSubWebsocket:
         self.client = client
         self._latency = None
         self._closing = False
-        if sys.version_info >= (3, 10):
-            self.timeout = asyncio.Event()
-        else:
-            self.timeout = asyncio.Event(loop=self.client.loop)
+        self.timeout = asyncio.Event()
 
     @property
     def latency(self) -> Optional[float]:

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 import asyncio
 import logging
+import sys
 import time
 import uuid
 from itertools import groupby
@@ -72,7 +73,10 @@ class PubSubWebsocket:
         self.client = client
         self._latency = None
         self._closing = False
-        self.timeout = asyncio.Event(loop=self.client.loop)
+        if sys.version_info >= (3, 10):
+            self.timeout = asyncio.Event()
+        else:
+            self.timeout = asyncio.Event(loop=self.client.loop)
 
     @property
     def latency(self) -> Optional[float]:


### PR DESCRIPTION
## Pull request summary

Python 3.10 drops the loop= parameter in Event(). Check the Python version so we don't raise a TypeError when running under 3.10+.

Fixes #251 

## Checklist

- [x] If code changes were made then they have been tested.
- [x] This PR fixes an issue.
