### PR TITLE
Implement the ability to leave channels and remove those channels from the cache

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,10 @@
 .. currentmodule:: twitchio
 
+Master
+======
+- TwitchIO
+    - Added the ability to leave channels to the Client.
+
 2.1.4
 ======
 - TwitchIO

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@
 Master
 ======
 - TwitchIO
-    - Added the ability to leave channels to the Client.
+    - Added the ability to part from channels to the Client.
 
 2.1.4
 ======

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -308,6 +308,20 @@ class Client:
 
             return Channel(name=name, websocket=self._connection)
 
+
+    async def leave_channels(self, channels: Union[List[str], Tuple[str]]):
+        """|coro|
+
+
+        Leave the specified channels.
+
+        Parameters
+        ------------
+        channels: Union[List[str], Tuple[str]]
+            The channels in either a list or tuple form to leave.
+        """
+        await self._connection.part_channels(*channels)
+
     async def join_channels(self, channels: Union[List[str], Tuple[str]]):
         """|coro|
 

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -308,16 +308,16 @@ class Client:
 
             return Channel(name=name, websocket=self._connection)
 
-    async def leave_channels(self, channels: Union[List[str], Tuple[str]]):
+    async def part_channels(self, channels: Union[List[str], Tuple[str]]):
         """|coro|
 
 
-        Leave the specified channels.
+        Part from the specified channels.
 
         Parameters
         ------------
         channels: Union[List[str], Tuple[str]]
-            The channels in either a list or tuple form to leave.
+            The channels in either a list or tuple form to part from.
         """
         await self._connection.part_channels(*channels)
 

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -308,7 +308,6 @@ class Client:
 
             return Channel(name=name, websocket=self._connection)
 
-
     async def leave_channels(self, channels: Union[List[str], Tuple[str]]):
         """|coro|
 

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -245,7 +245,6 @@ class WSConnection:
         channels = channels or self._initial_channels
         await self.join_channels(*channels)
 
-
     async def part_channels(self, *channels: str):
         """|coro|
 
@@ -262,8 +261,6 @@ class WSConnection:
     async def _part_channel(self, entry):
         channel = re.sub("[#]", "", entry).lower()
         await self.send(f"PART #{channel}\r\n")
-
-        
 
     async def join_channels(self, *channels: str):
         """|coro|

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -245,6 +245,26 @@ class WSConnection:
         channels = channels or self._initial_channels
         await self.join_channels(*channels)
 
+
+    async def part_channels(self, *channels: str):
+        """|coro|
+
+        Attempt to part the provided channels.
+
+        Parameters
+        ------------
+        *channels: str
+            An argument list of channels to attempt parting.
+        """
+        for channel in channels:
+            asyncio.create_task(self._part_channel(channel))
+
+    async def _part_channel(self, entry):
+        channel = re.sub("[#]", "", entry).lower()
+        await self.send(f"PART #{channel}\r\n")
+
+        
+
     async def join_channels(self, *channels: str):
         """|coro|
 
@@ -357,8 +377,9 @@ class WSConnection:
         self._last_ping = time.time()
         await self.send("PONG :tmi.twitch.tv\r\n")
 
-    async def _part(self, parsed):  # TODO
+    async def _part(self, parsed):
         log.debug(f'ACTION: PART:: {parsed["channel"]}')
+        del self._cache[parsed["channel"]]
 
     async def _privmsg(self, parsed):  # TODO(Update Cache properly)
         log.debug(f'ACTION: PRIVMSG:: {parsed["channel"]}')


### PR DESCRIPTION
## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
This PR resolves #206. It's a very simple commit. It adds the leave_channels coroutine to the client class. In addition, it adds a simple implementation to the websocket. For each channel supplied to the part_channels method, a simple PART IRC message is sent to Twitch. When we successfully receive a PART back, that channel is removed from the cache. Even if we send multiple PART messages for a single channel, Twitch responds with a single PART acknowledgment, so I believe using `del` here is fine. 
`_cache_add` in `websocket.py` checks if a key exists for a channel before accessing it, so there shouldn't be any KeyErrors in the websocket code. The only thing I need input on is some of the check methods like the one below. These types of functions exist in channel.py, chatter.py, and core.py (Contexts)) and do not safely check for the existence of the channel in the cache before accessing it. Should these unsafe accesses of the cache be updated or left as is? Theoretically, it should be fine for Chatters, Channels, and Contexts created automatically by Twitchio since the information would be cached before events are dispatched; however, I just wanted to double-check.

```python
// Line 68 of channel.py

    def _bot_is_mod(self):
        cache = self._ws._cache[self.name]  # noqa <---- Could possibly KeyError, but shouldn't when used correctly
        for user in cache:
            if user.name == self._ws.nick:
                try:
                    mod = user.is_mod
                except AttributeError:
                    return False

                return mod
``` 

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes. (Docs should auto-update with the doc-string of the new methods?)
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)