### PR TITLE
Fix incorrect User.view_count type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,10 @@
 .. currentmodule:: twitchio
 
+Master
+======
+- User.view_count
+    - Fix incorrect type
+
 2.2.0
 =====
 - ext.sounds

--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -872,7 +872,7 @@ class User(PartialUser):
         self.description: str = data["description"]
         self.profile_image: str = data["profile_image_url"]
         self.offline_image: str = data["offline_image_url"]
-        self.view_count: Tuple[int] = (data["view_count"],)  # this isn't supposed to be a tuple but too late to fix it!
+        self.view_count: int = data["view_count"]
         self.created_at = parse_timestamp(data["created_at"])
         self.email: Optional[str] = data.get("email")
         self._cached_rewards = None


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary
`View_count` has incorrect type, tuple. This fixes it, `int`


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)