### PR TITLE
Add login method to Client

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 
 2.2.0
 =====
+- Client
+    - Add login method
+
 - ext.sounds
     - Added sounds extension. Check the sounds documentation for more information.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 
 2.2.0
 =====
-- Client
+- Add :meth:`Client.login`
     - Add login method
 
 - ext.sounds

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -141,6 +141,13 @@ class Client:
         self._waiting = []
         return self
 
+    async def login(self):
+        """|coro|
+        Validate token and get user associated with the token.
+        To be used if an IRC connection is not desired.
+        """
+        return await self._http.validate()
+
     def run(self):
         """
         A blocking function that starts the asyncio event loop,


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

This PR is intended to make this package compatible with the https://github.com/home-assistant/core twitch integration. This offers asyncio. The current supporting pypi package is sync.
For this integration there is currently no need for logging into the irc chat. Running the current `run` method actually kills the running loop, crashing the entire program. Perhaps I missed something in this project that already allows me to just login. If not, this PR is a step in the right direction imo.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)