### PR TITLE
checks: Add is_broadcaster check to PartialChatter class.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@
     - Fix Message._timestamp value when tag is not provided by twitch
     - Fix :func:`Client.wait_for_ready`
     - Remove loop= parameter for :func:`Client.wait_for` for 3.10 compatibility
+    - Add `is_broadcaster` check to `PartialChatter` class. This is accessible as `ctx.author.is_broadcaster`.
 
 - ext.pubsub
     - Add channel subscription pubsub model.

--- a/twitchio/chatter.py
+++ b/twitchio/chatter.py
@@ -133,7 +133,9 @@ class Chatter(PartialChatter):
         self._colour = self._tags["color"]
 
         if self._badges:
-            self._cached_badges = {k: v for k, v in [badge.split("/") for badge in self._badges.split(",")]}
+            self._cached_badges = {
+                k: v for k, v in [badge.split("/") for badge in self._badges.split(",")]
+            }
 
     def _bot_is_mod(self):
         cache = self._ws._cache[self._channel.name]  # noqa
@@ -178,6 +180,12 @@ class Chatter(PartialChatter):
     def color(self) -> str:
         """The users color."""
         return self.colour
+
+    @property
+    def is_broadcaster(self) -> bool:
+        """A boolean indicating whether the User is a moderator of the current channel."""
+
+        return "broadcaster" in self.badges
 
     @property
     def is_mod(self) -> bool:


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

I have added the is_broadcaster check to the PartialChatter class so
that it is accessible at ctx.author.is_broadcaster. This checks for the
presence of the broadcatser badge within the badges received in
PRIVMSG.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)