### PR TITLE
Removed event loop termination on WS close

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Massive documentation updates
 
 - TwitchIO
     - Fix bug where # prefixed channel names in initial_channels would not trigger :func:`Client.event_ready``
+    - Removed unexpected loop termination from `WSConnection._close()`
 
 - ext.commands
     - :func:`Bot.handle_commands` now also invokes on threads / replies

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -520,5 +520,4 @@ class WSConnection:
         if self._websocket:
             await self._websocket.close()
         if self._client._http.session:
-            await self._client._http.session.close()
-        self._loop.stop()
+            await self._client._http.session.close()        


### PR DESCRIPTION
## Pull request summary

Calling `close()` on `commands.Bot` kills the main event loop for my application. I don't think it's wise to assume responsibility for terminating the event loop when closing the WebSocket connection. If I don't provide a loop to the Bot/Client, the default event loop will be acquired via `asyncio.get_event_loop()` which means termination results in side-effects for anything else running on that loop. Even if I pass in an event loop to the constructor of Bot/Client, the lifecycle of that loop should not be assumed by this module.


## Checklist
- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)