### PR TITLE
Fix module reloading incorrectly on exception

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Massive documentation updates
 - ext.commands
     - :func:`Bot.handle_commands` now also invokes on threads / replies
     - Cooldowns are now handled correctly per bucket.
+    - Fix issue with :func:`Bot.reload_module` where module is reloaded incorrectly if exception occurs
 
 - ext.pubsub
     - Channel subscription model fixes.

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -441,6 +441,7 @@ class Bot(Client):
         except Exception as e:
             sys.modules.update(modules)
             module.prepare(self)  # type: ignore
+            self._modules[name] = module
             raise
 
     def add_cog(self, cog: Cog):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
Currently when reloading a module, if there is an exception in `Bot.load_module`, such as on import, the module is improperly restored and left out of `Bot._modules` (since it gets removed by `Bot.unload_module`). This causes an issue where you can't load, unload, or reload the module again without restarting the bot. This PR fixes this issue.


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)