### PR TITLE
Add type conversion for VAR_POSITIONAL arguments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Massive documentation updates
     - :func:`Bot.handle_commands` now also invokes on threads / replies
     - Cooldowns are now handled correctly per bucket.
     - Fix issue with :func:`Bot.reload_module` where module is reloaded incorrectly if exception occurs
+    - Add type conversion for variable positional arguments
 
 - ext.pubsub
     - Channel subscription model fixes.

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -186,7 +186,8 @@ class Command:
                 parsed.clear()
                 break
             elif param.VAR_POSITIONAL:
-                args.extend(parsed.values())
+                args.extend([await self._convert_types(context, param, argument) for argument in parsed.values()])
+                parsed.clear()
                 break
 
         if parsed:


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
Typing information is currently ignored only for variable positional arguments. This PR adds type conversion functionality to them. Each argument starting at the variable positional arguments is individually converted.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)