### PR TITLE
More EventSub Subscription Types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Future via PR #303
             - Callback function is :func:`event_eventsub_notification_subscription_gift(payload)`
         - Added Resubscription Message subscriptions for Resub messages:
             - Subscribed via :func:`esclient.subscribe_channel_subscription_messages(broadcaster=CHANNEL_ID)`
-            -Callback function is :func:`event_eventsub_notification_subscription_message(payload)`
+            - Callback function is :func:`event_eventsub_notification_subscription_message(payload)`
         - Added :func:`EventSubClient.delete_all_active_subscriptions()` for convenience
 
 Master

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,10 +13,10 @@ Master
 - ext.eventsub
     - Additions
         - Added Gift Subcriptions subscriptions for gifting other users Subs:
-            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.subscribe_channel_subscription_gifts`
+            - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.subscribe_channel_subscription_gifts`
             - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_gift`
         - Added Resubscription Message subscriptions for Resub messages:
-            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.esclient.subscribe_channel_subscription_messages`
+            - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.esclient.subscribe_channel_subscription_messages`
             - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_message`
         - Added :func:`twitchio.ext.eventsub.server.EventSubClient.delete_all_active_subscriptions` for convenience
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ Master
             - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.subscribe_channel_subscription_gifts`
             - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_gift`
         - Added Resubscription Message subscriptions for Resub messages:
-            - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.esclient.subscribe_channel_subscription_messages`
+            - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.subscribe_channel_subscription_messages`
             - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_message`
         - Added :func:`twitchio.ext.eventsub.EventSubClient.delete_all_active_subscriptions` for convenience
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,17 @@
 :orphan:
 
+Future via PR #303
+======
+- ext.eventsub
+    - Additions
+        - Added Gift Subcriptions subscriptions for giving other users Subs:
+            - Subscribed via :func:`esclient.subscribe_channel_subscription_gifts(broadcaster=CHANNEL_ID)`
+            - Callback function is :func:`event_eventsub_notification_subscription_gift(payload)`
+        - Added Resubscription Message subscriptions for Resub messages:
+            - Subscribed via :func:`esclient.subscribe_channel_subscription_messages(broadcaster=CHANNEL_ID)`
+            -Callback function is :func:`event_eventsub_notification_subscription_message(payload)`
+        - Added :func:`EventSubClient.delete_all_active_subscriptions()` for convenience
+
 Master
 ======
 - TwitchIO

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,17 +1,5 @@
 :orphan:
 
-Future via PR #303
-======
-- ext.eventsub
-    - Additions
-        - Added Gift Subcriptions subscriptions for giving other users Subs:
-            - Subscribed via :func:`esclient.subscribe_channel_subscription_gifts(broadcaster=CHANNEL_ID)`
-            - Callback function is :func:`event_eventsub_notification_subscription_gift(payload)`
-        - Added Resubscription Message subscriptions for Resub messages:
-            - Subscribed via :func:`esclient.subscribe_channel_subscription_messages(broadcaster=CHANNEL_ID)`
-            - Callback function is :func:`event_eventsub_notification_subscription_message(payload)`
-        - Added :func:`EventSubClient.delete_all_active_subscriptions()` for convenience
-
 Master
 ======
 - TwitchIO
@@ -21,6 +9,17 @@ Master
 - ext.pubsub
     - Bug fixes
         - :class:`~twitchio.ext.pubsub.PubSubModerationAction` now handles missing keys
+
+- ext.eventsub
+    - Additions
+        - Added Gift Subcriptions subscriptions for gifting other users Subs:
+            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.subscribe_channel_subscription_gifts(broadcaster=CHANNEL_ID)`
+            - Callback function is ``event_eventsub_notification_subscription_gift(payload)``
+        - Added Resubscription Message subscriptions for Resub messages:
+            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.esclient.subscribe_channel_subscription_messages(broadcaster=CHANNEL_ID)`
+            - Callback function is ``event_eventsub_notification_subscription_message(payload)``
+        - Added :func:`twitchio.ext.eventsub.server.EventSubClient.delete_all_active_subscriptions()` for convenience
+
 
 2.3.0
 =====

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,12 +13,12 @@ Master
 - ext.eventsub
     - Additions
         - Added Gift Subcriptions subscriptions for gifting other users Subs:
-            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.subscribe_channel_subscription_gifts(broadcaster=CHANNEL_ID)`
-            - Callback function is ``event_eventsub_notification_subscription_gift(payload)``
+            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.subscribe_channel_subscription_gifts`
+            - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_gift`
         - Added Resubscription Message subscriptions for Resub messages:
-            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.esclient.subscribe_channel_subscription_messages(broadcaster=CHANNEL_ID)`
-            - Callback function is ``event_eventsub_notification_subscription_message(payload)``
-        - Added :func:`twitchio.ext.eventsub.server.EventSubClient.delete_all_active_subscriptions()` for convenience
+            - Subscribed via :func:`twitchio.ext.eventsub.server.EventSubClient.esclient.subscribe_channel_subscription_messages`
+            - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_message`
+        - Added :func:`twitchio.ext.eventsub.server.EventSubClient.delete_all_active_subscriptions` for convenience
 
 
 2.3.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,7 @@ Master
         - Added Resubscription Message subscriptions for Resub messages:
             - Subscribed via :func:`twitchio.ext.eventsub.EventSubClient.esclient.subscribe_channel_subscription_messages`
             - Callback function is :func:`twitchio.ext.eventsub.event_eventsub_notification_subscription_message`
-        - Added :func:`twitchio.ext.eventsub.server.EventSubClient.delete_all_active_subscriptions` for convenience
+        - Added :func:`twitchio.ext.eventsub.EventSubClient.delete_all_active_subscriptions` for convenience
 
 
 2.3.0

--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -189,13 +189,13 @@ API Reference
 
 .. attributetable::: ChannelSubscriptionGiftData
 
-.. autoclass:: ChannelSubscribeData
+.. autoclass:: ChannelSubscriptionGiftData
     :members:
     :inherited-members:
 
 .. attributetable::: ChannelSubscriptionMessageData
 
-.. autoclass:: ChannelSubscribeData
+.. autoclass:: ChannelSubscriptionMessageData
     :members:
     :inherited-members:
 

--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -108,6 +108,14 @@ This is a list of events dispatched by the eventsub ext.
 
     Called when someone subscribes to a channel that you've subscribed to.
 
+.. function:: event_eventsub_notification_subscription_gift(event: ChannelSubscriptionGiftData)
+
+    Called when someone gifts a subscription to a channel that you've subscribed to.
+
+.. function:: event_eventsub_notification_subscription_message(event: ChannelSubscriptionMessageData)
+
+    Called when someone resubscribes with a message to a channel that you've subscribed to.
+
 .. function:: event_eventsub_notification_cheer(event: ChannelCheerData)
 
     Called when someone cheers on a channel you've subscribed to.
@@ -174,6 +182,18 @@ API Reference
     :inherited-members:
 
 .. attributetable::: ChannelSubscribeData
+
+.. autoclass:: ChannelSubscribeData
+    :members:
+    :inherited-members:
+
+.. attributetable::: ChannelSubscriptionGiftData
+
+.. autoclass:: ChannelSubscribeData
+    :members:
+    :inherited-members:
+
+.. attributetable::: ChannelSubscriptionMessageData
 
 .. autoclass:: ChannelSubscribeData
     :members:

--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -160,8 +160,7 @@ API Reference
 
 .. autoclass:: EventSubClient
     :members:
-
-(The above is broken, and does not show members)
+    :undoc-members:
 
 .. attributetable:: Subscription
 

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -242,7 +242,7 @@ class ChannelSubscriptionGiftData(EventData):
     """
     A Subscription Gift event
     Explicitly, the act of giving another user a Subscription.
-    Receiving a gift-subscription uses ChannelSubscribeData above, with is_gift==True
+    Receiving a gift-subscription uses ChannelSubscribeData above, with is_gift is ``True``
 
     Attributes
     -----------
@@ -256,7 +256,7 @@ class ChannelSubscriptionGiftData(EventData):
         The tier of the subscription
     total: :class:`int`
         The total number of subs gifted by a user at once
-    cumulative: Optional[:class:`int`]
+    cumulative_total: Optional[:class:`int`]
         The total number of subs gifted by a user overall. Will be ``None`` if ``is_anonymous`` is ``True``
     """
 
@@ -265,10 +265,10 @@ class ChannelSubscriptionGiftData(EventData):
     def __init__(self, client: EventSubClient, data: dict):
         self.is_anonymous: bool = data["is_anonymous"]
         self.user: Optional[PartialUser] = _transform_user(client, data, "user") if not self.is_anonymous else None
-        self.broadcaster = _transform_user(client, data, "broadcaster_user")
+        self.broadcaster: Optional[PartialUser] = _transform_user(client, data, "broadcaster_user")
         self.tier = int(data["tier"])
         self.total = int(data["total"])
-        self.cumulative = int(data["cumulative_total"]) if not self.is_anonymous else None
+        self.cumulative_total: Optional[int] = int(data["cumulative_total"]) if not self.is_anonymous else None
 
 
 class ChannelSubscriptionMessageData(EventData):
@@ -286,9 +286,9 @@ class ChannelSubscriptionMessageData(EventData):
         The tier of the subscription
     message: :class:`str`
         The user's resubscription message
-    emote_data: :class:`List[Dict]`
+    emote_data: :class:`list`
         emote data within the user's resubscription message. Not the emotes themselves
-    cumulative: :class:`int`
+    cumulative_months: :class:`int`
         The total number of months a user has subscribed to the channel
     streak: Optional[:class:`int`]
         The total number of months subscribed in a row. ``None`` if the user declines to share it.
@@ -302,11 +302,11 @@ class ChannelSubscriptionMessageData(EventData):
         self.user = _transform_user(client, data, "user")
         self.broadcaster = _transform_user(client, data, "broadcaster_user")
         self.tier = int(data["tier"])
-        self.message = data["message"]["text"]
+        self.message: str = data["message"]["text"]
         self.emote_data: List[Dict] = data["message"].get("emotes", [])
-        self.cumulative = data["cumulative_months"]
-        self.streak = data["streak_months"]
-        self.duration = data["duration_months"]
+        self.cumulative_months: int = data["cumulative_months"]
+        self.streak: Optional[int] = data["streak_months"]
+        self.duration: int = data["duration_months"]
 
 
 class ChannelCheerData(EventData):

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -286,6 +286,8 @@ class ChannelSubscriptionMessageData(EventData):
         The tier of the subscription
     message: :class:`str`
         The user's resubscription message
+    emote_data: :class:`List[Dict]`
+        emote data within the user's resubscription message. Not the emotes themselves
     cumulative: :class:`int`
         The total number of months a user has subscribed to the channel
     streak: Optional[:class:`int`]
@@ -294,13 +296,14 @@ class ChannelSubscriptionMessageData(EventData):
         The length of the subscription. Typically 1, but some users may buy subscriptions for several months.
     """
 
-    __slots__ = "user", "broadcaster", "tier", "message", "cumulative", "streak", "duration"
+    __slots__ = "user", "broadcaster", "tier", "message", "emote_data", "cumulative", "streak", "duration"
 
     def __init__(self, client: EventSubClient, data: dict):
         self.user = _transform_user(client, data, "user")
         self.broadcaster = _transform_user(client, data, "broadcaster_user")
         self.tier = int(data["tier"])
-        self.message = data["message"]["text"] # There's also an "emotes" part, but its a bunch of data
+        self.message = data["message"]["text"]
+        self.emote_data: List[Dict] = data["message"]["emotes"]
         self.cumulative = data["cumulative_months"]
         self.streak = data["streak_months"]
         self.duration = data["duration_months"]

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -303,7 +303,7 @@ class ChannelSubscriptionMessageData(EventData):
         self.broadcaster = _transform_user(client, data, "broadcaster_user")
         self.tier = int(data["tier"])
         self.message = data["message"]["text"]
-        self.emote_data: List[Dict] = data["message"]["emotes"]
+        self.emote_data: List[Dict] = data["message"].get("emotes", [])
         self.cumulative = data["cumulative_months"]
         self.streak = data["streak_months"]
         self.duration = data["duration_months"]

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -238,6 +238,74 @@ class ChannelSubscribeData(EventData):
         self.is_gift: bool = data["is_gift"]
 
 
+class ChannelSubscriptionGiftData(EventData):
+    """
+    A Subscription Gift event
+    Explicitly, the act of giving another user a Subscription.
+    Receiving a gift-subscription uses ChannelSubscribeData above, with is_gift==True
+
+    Attributes
+    -----------
+    is_anonymous: :class:`bool`
+        Whether the gift sub was anonymous
+    user: Optional[:class:`twitchio.PartialUser`]
+        The user that gifted subs. Will be ``None`` if ``is_anonymous`` is ``True``
+    broadcaster: :class:`twitchio.PartialUser`
+        The channel that was subscribed to
+    tier: :class:`int`
+        The tier of the subscription
+    total: :class:`int`
+        The total number of subs gifted by a user at once
+    cumulative: Optional[:class:`int`]
+        The total number of subs gifted by a user overall. Will be ``None`` if ``is_anonymous`` is ``True``
+    """
+
+    __slots__ = "is_anonymous", "user", "broadcaster", "tier", "total", "cumulative"
+
+    def __init__(self, client: EventSubClient, data: dict):
+        self.is_anonymous: bool = data["is_anonymous"]
+        self.user: Optional[PartialUser] = _transform_user(client, data, "user") if not self.is_anonymous else None
+        self.broadcaster = _transform_user(client, data, "broadcaster_user")
+        self.tier = int(data["tier"])
+        self.total = int(data["total"])
+        self.cumulative = int(data["cumulative_total"]) if not self.is_anonymous else None
+
+
+class ChannelSubscriptionMessageData(EventData):
+    """
+    A Subscription Message event.
+    A combination of resubscriptions + the messages users type as part of the resub.
+
+    Attributes
+    -----------
+    user: :class:`twitchio.PartialUser`
+        The user who subscribed
+    broadcaster: :class:`twitchio.PartialUser`
+        The channel that was subscribed to
+    tier: :class:`int`
+        The tier of the subscription
+    message: :class:`str`
+        The user's resubscription message
+    cumulative: :class:`int`
+        The total number of months a user has subscribed to the channel
+    streak: Optional[:class:`int`]
+        The total number of months subscribed in a row. ``None`` if the user declines to share it.
+    duration: :class:`int`
+        The length of the subscription. Typically 1, but some users may buy subscriptions for several months.
+    """
+
+    __slots__ = "user", "broadcaster", "tier", "message", "cumulative", "streak", "duration"
+
+    def __init__(self, client: EventSubClient, data: dict):
+        self.user = _transform_user(client, data, "user")
+        self.broadcaster = _transform_user(client, data, "broadcaster_user")
+        self.tier = int(data["tier"])
+        self.message = data["message"]["text"] # There's also an "emotes" part, but its a bunch of data
+        self.cumulative = data["cumulative_months"]
+        self.streak = data["streak_months"]
+        self.duration = data["duration_months"]
+
+
 class ChannelCheerData(EventData):
     """
     A Cheer event
@@ -990,6 +1058,8 @@ _DataType = Union[
     ChannelBanData,
     ChannelUnbanData,
     ChannelSubscribeData,
+    ChannelSubscriptionGiftData,
+    ChannelSubscriptionMessageData,
     ChannelCheerData,
     ChannelUpdateData,
     ChannelFollowData,
@@ -1024,6 +1094,8 @@ class _SubscriptionTypes(metaclass=_SubTypesMeta):
 
     follow = "channel.follow", 1, ChannelFollowData
     subscription = "channel.subscribe", 1, ChannelSubscribeData
+    subscription_gift = "channel.subscription.gift", 1, ChannelSubscriptionGiftData
+    subscription_message = "channel.subscription.message", 1, ChannelSubscriptionMessageData
     cheer = "channel.cheer", 1, ChannelCheerData
     raid = "channel.raid", 1, ChannelRaidData
     ban = "channel.ban", 1, ChannelBanData

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -46,6 +46,12 @@ class EventSubClient(web.Application):
     async def delete_subscription(self, subscription_id: str):
         await self._http.delete_subscription(subscription_id)
 
+    async def delete_all_active_subscriptions(self):
+        # A convenience method
+        active_subscriptions = await self.get_subscriptions("enabled")
+        for subscription_id in active_subscriptions:
+            await self.delete_subscription(subscription_id)
+
     async def get_subscriptions(self, status: str = None):
         # All possible statuses are:
         #
@@ -113,6 +119,12 @@ class EventSubClient(web.Application):
 
     def subscribe_channel_subscriptions(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription, broadcaster)
+
+    def subscribe_channel_subscription_gift(self, broadcaster: Union[PartialUser, str, int]):
+        return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription_gift, broadcaster)
+
+    def subscribe_channel_subscriptions_message(self, broadcaster: Union[PartialUser, str, int]):
+        return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription_message, broadcaster)
 
     def subscribe_channel_cheers(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.cheer, broadcaster)

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -120,10 +120,10 @@ class EventSubClient(web.Application):
     def subscribe_channel_subscriptions(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription, broadcaster)
 
-    def subscribe_channel_subscription_gift(self, broadcaster: Union[PartialUser, str, int]):
+    def subscribe_channel_subscription_gifts(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription_gift, broadcaster)
 
-    def subscribe_channel_subscriptions_message(self, broadcaster: Union[PartialUser, str, int]):
+    def subscribe_channel_subscription_messages(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.subscription_message, broadcaster)
 
     def subscribe_channel_cheers(self, broadcaster: Union[PartialUser, str, int]):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
Added two additional EventSub subscription types, to match up with regular subscriptions:

### Subscription Gifts
- server: `EventSubClient.subscribe_channel_subscription_gifts`
- models: `ChannelSubscriptionGiftData`
- models: `_SubscriptionTypes.subscription_gift`

All needed to enable subscriptions for the gifting of subs. Distinctly different from `ChannelSubscribeData` with `is_gift==True`, which is receiving gifted subs.

### Subscription Messages
- server: `EventSubClient.subscribe_channel_subscription_messages`
- models: `ChannelSubscriptionMessageData`
- models: `_SubscriptionTypes.subscription_message`

Needed for enabling resubscription messages, and other associated resub data like duration, streak, etc.

### Additional
Also created `EventSubClient.delete_all_active_subscriptions()`, a convenience method for deleting any active EventSubs, in case a user wants to start fresh each time (to avoid duplicate subscriptions).

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested. (through localhost with Twitch's CLI, not yet through public callback.)
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)