### PR TITLE
Fix message content while handling commands in reply messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Master
 - TwitchIO
     - Bug fixes
         - Added ``self.registered_callbacks = {}`` to Bot and :func:`Client.from_client_credentials`
+        - Fixed message content while handling commands in reply messages
 
 - ext.pubsub
     - Bug fixes

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -330,7 +330,7 @@ class Bot(Client):
 
         """
         if "reply-parent-msg-id" in message.tags:
-            message.content = message.content.split(" ")[1]
+            message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
 


### PR DESCRIPTION
Instead of stripping only the user who was replied to, currently only the second word of the message is set as message content when handling commands. The rest of the message got stripped to. 

So `@dnns01_ This is a reply` was changed to `This` instead of `This is a reply`

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)