### PR TITLE
Reconstruct original message after handling commands

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Master
 - TwitchIO
     - Bug fixes
         - Added ``self.registered_callbacks = {}`` to Bot and :func:`Client.from_client_credentials`
+        - Fixed message content while handling commands in reply messages
 
 - ext.pubsub
     - Bug fixes

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -330,7 +330,7 @@ class Bot(Client):
 
         """
         if "reply-parent-msg-id" in message.tags:
-            message.content = message.content.split(" ")[1]
+            message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
 

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -329,10 +329,14 @@ class Bot(Client):
             The message object to get content of and context for.
 
         """
+        original_content = message.content
+
         if "reply-parent-msg-id" in message.tags:
             message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
+
+        message.content = original_content
 
     async def invoke(self, context):
         # TODO Docs


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
When reply messages are received, the user is cut off to be able to handle commands. After commands are now the original message is reconstructed, including the username who was replied to.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)