### PR TITLE
Handle commands in replies without changing message.content

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Master
 - TwitchIO
     - Bug fixes
         - Added ``self.registered_callbacks = {}`` to Bot and :func:`Client.from_client_credentials`
+        - Fixed message content while handling commands in reply messages
 
 - ext.pubsub
     - Bug fixes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,11 +5,11 @@ Master
 - TwitchIO
     - Bug fixes
         - Added ``self.registered_callbacks = {}`` to Bot and :func:`Client.from_client_credentials`
-        - Fixed message content while handling commands in reply messages
 
 - ext.commands:
   - Bug fixes
       - Add type conversion for variable positional arguments
+      - Fixed message content while handling commands in reply messages
       
 - ext.pubsub
     - Bug fixes

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -172,10 +172,8 @@ class Bot(Client):
         # TODO Docs
         prefixes = await self.__get_prefixes__(message)
         message_content = message.content
-
         if "reply-parent-msg-id" in message.tags:
             message_content = message_content.split(" ", 1)[1]
-
         if not isinstance(prefixes, str):
             for prefix in prefixes:
                 if message_content.startswith(prefix):

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -330,7 +330,7 @@ class Bot(Client):
 
         """
         if "reply-parent-msg-id" in message.tags:
-            message.content = message.content.split(" ")[1]
+            message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
 

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -329,10 +329,14 @@ class Bot(Client):
             The message object to get content of and context for.
 
         """
+        original_content = message.content
+
         if "reply-parent-msg-id" in message.tags:
             message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
+
+        message.content = original_content
 
     async def invoke(self, context):
         # TODO Docs

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -294,7 +294,7 @@ class Bot(Client):
         content = message.content
         if "reply-parent-msg-id" in message.tags:  # Remove @username from reply message
             content = content.split(" ", 1)[1]
-        content = content[len(prefix)::].lstrip()  # Strip prefix and remainder whitespace
+        content = content[len(prefix) : :].lstrip()  # Strip prefix and remainder whitespace
         view = StringParser()
         parsed = view.process_string(content)  # Return the string as a dict view
 

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -339,8 +339,6 @@ class Bot(Client):
         context = await self.get_context(message)
         await self.invoke(context)
 
-        message.content = original_content
-
     async def invoke(self, context):
         # TODO Docs
         if not context.prefix or not context.is_valid:

--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -171,12 +171,16 @@ class Bot(Client):
     async def get_prefix(self, message):
         # TODO Docs
         prefixes = await self.__get_prefixes__(message)
+        message_content = message.content
+
+        if "reply-parent-msg-id" in message.tags:
+            message_content = message_content.split(" ", 1)[1]
 
         if not isinstance(prefixes, str):
             for prefix in prefixes:
-                if message.content.startswith(prefix):
+                if message_content.startswith(prefix):
                     return prefix
-        elif message.content.startswith(prefixes):
+        elif message_content.startswith(prefixes):
             return prefixes
         else:
             return None
@@ -287,7 +291,10 @@ class Bot(Client):
         prefix = await self.get_prefix(message)
         if not prefix:
             return cls(message=message, prefix=prefix, valid=False, bot=self)
-        content = message.content[len(prefix) : :].lstrip()  # Strip prefix and remainder whitespace
+        content = message.content
+        if "reply-parent-msg-id" in message.tags:  # Remove @username from reply message
+            content = content.split(" ", 1)[1]
+        content = content[len(prefix)::].lstrip()  # Strip prefix and remainder whitespace
         view = StringParser()
         parsed = view.process_string(content)  # Return the string as a dict view
 
@@ -329,14 +336,8 @@ class Bot(Client):
             The message object to get content of and context for.
 
         """
-        original_content = message.content
-
-        if "reply-parent-msg-id" in message.tags:
-            message.content = message.content.split(" ", 1)[1]
         context = await self.get_context(message)
         await self.invoke(context)
-
-        message.content = original_content
 
     async def invoke(self, context):
         # TODO Docs

--- a/twitchio/ext/eventsub/http.py
+++ b/twitchio/ext/eventsub/http.py
@@ -27,13 +27,13 @@ class EventSubHTTP:
         route = Route("POST", "eventsub/subscriptions", body=payload, token=self._token)
         return await self._http.request(route, paginate=False, force_app_token=True)
 
-    async def delete_subscription(self, substription: Union[str, Subscription]):
-        if isinstance(substription, models.Subscription):
+    async def delete_subscription(self, subscription: Union[str, Subscription]):
+        if isinstance(subscription, models.Subscription):
             return await self._http.request(
-                Route("DELETE", "eventsub/subscriptions", query=[("id", substription.id)]), paginate=False
+                Route("DELETE", "eventsub/subscriptions", query=[("id", subscription.id)]), paginate=False
             )
         return await self._http.request(
-            Route("DELETE", "eventsub/subscriptions", query=[("id", substription)]), paginate=False
+            Route("DELETE", "eventsub/subscriptions", query=[("id", subscription)]), paginate=False
         )
 
     async def get_subscriptions(self, status: str = None):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
At the moment, the message that is stored in a commands context will be changed. With this PR, the bug with replies will be fixed without changing the message itself.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)