### PR TITLE
Fix #209

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 
 Master
 ======
+- TwitchIO
+    - Additions
+        - Added :func:`~twitchio.Client.event_channel_join_failure` event:
+            - This is dispatched when the bot fails to join a channel
+            - This also makes the channel join error message in logs optional
+    - Bug fixes
+        - Fix channel join failures causing `ValueError: list.remove(x): x not in list` when joining channels after the initial start
+
 - ext.commands
     - Bug fixes
         - Make sure double-quotes are properly tokenized for bot commands

--- a/docs/twitchio.rst
+++ b/docs/twitchio.rst
@@ -18,7 +18,8 @@ Client
     :members:
     :exclude-members: event_ready, event_raw_data, event_message,
                       event_join, event_part, event_mode, event_userstate,
-                      event_raw_usernotice, event_usernotice_subscription, event_error
+                      event_raw_usernotice, event_usernotice_subscription, event_error,
+                      event_channel_join_failure
 
 Event Reference
 -----------------
@@ -34,6 +35,7 @@ Event Reference
 .. automethod:: Client.event_raw_usernotice(channel: Channel, tags: dict)
 .. automethod:: Client.event_usernotice_subscription(metadata)
 .. automethod:: Client.event_error(error: Exception, data: Optional[str] = None)
+.. automethod:: Client.event_channel_join_failure(channel: str)
 
 Exceptions
 ------------

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -1007,3 +1007,16 @@ class Client:
         channel: :class:`.Channel`
             The channel that was joined.
         """
+        pass
+
+    async def event_channel_join_failure(self, channel: str):
+        """|coro|
+
+        Event called when the bot fails to join a channel.
+
+        Parameters
+        ----------
+        channel: `str`
+            The channel name that was attempted to be joined.
+        """
+        logger.error(f'The channel "{channel}" was unable to be joined. Check the channel is valid.')

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -294,7 +294,7 @@ class WSConnection:
         try:
             await asyncio.wait_for(fut, timeout=timeout)
         except asyncio.TimeoutError:
-            log.error(f'The channel "{channel}" was unable to be joined. Check the channel is valid.')
+            self.dispatch("channel_join_failure", channel)
             self._join_pending.pop(channel)
 
             data = (
@@ -343,7 +343,7 @@ class WSConnection:
             self.dispatch("ready")
             self._init = True
         elif code == 353:
-            if parsed["channel"] == "TWITCHIOFAILURE":
+            if parsed["channel"] == "TWITCHIOFAILURE" and parsed["batches"][0] in self._initial_channels:
                 self._initial_channels.remove(parsed["batches"][0])
             if parsed["channel"] in [c.lower().lstrip("#") for c in self._initial_channels] and not self._init:
                 self._join_load[parsed["channel"]] = None


### PR DESCRIPTION
This closes #209

## Pull request summary

This makes the `The channel "CHANNELNAME" was unable to be joined. Check the channel is valid.` error message in logging optional. Additionally allows automatic handling of such situations through the means of a new `event_channel_join_failure` event.
This also fixes the following Task exception:
```
Task exception was never retrieved
future: <Task finished name='Task-123456' coro=<WSConnection._join_future_handle() done, defined at .../twitchio/websocket.py:293> exception=ValueError('list.remove(x): x not in list')>
Traceback (most recent call last):
  File ".../twitchio/websocket.py", line 295, in _join_future_handle
    await asyncio.wait_for(fut, timeout=timeout)
  File ".../asyncio/tasks.py", line 501, in wait_for
    raise exceptions.TimeoutError()
asyncio.exceptions.TimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../twitchio/websocket.py", line 305, in _join_future_handle
    await self._process_data(data)
  File ".../twitchio/websocket.py", line 314, in _process_data
    return await self._code(parsed, parsed["code"])
  File ".../twitchio/websocket.py", line 347, in _code
    self._initial_channels.remove(parsed["batches"][0])
ValueError: list.remove(x): x not in list
```

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)