### PR TITLE
set empty list when `tag_ids` is empty(None) when initialized

### DIFF
--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -972,7 +972,7 @@ class Stream:
         self.started_at = parse_timestamp(data["started_at"])
         self.language: str = data["language"]
         self.thumbnail_url: str = data["thumbnail_url"]
-        self.tag_ids: List[str] = data["tag_ids"]
+        self.tag_ids: List[str] = data["tag_ids"] or []
         self.is_mature: bool = data["is_mature"]
 
     def __repr__(self):


### PR DESCRIPTION
## Pull request summary

When streaming starts with no tags (that should be added by streamers)

Twitch sends empty `tag_ids` which makes `Steam` attribute `tag_ids` as `None`

as there are no dataclass or models for `tag_ids` (that works like list)

so there should be empty `list []` instead of `None`


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)