### PR TITLE
Fix error in Popen call of ffmpeg

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ Master
     - Bug fixes
         - Make sure double-quotes are properly tokenized for bot commands
 
+- ext.sound
+    - Bug fixes
+        - Make system calls to ffmpeg are more robust (works on windows and linux)
+
 2.4.0
 ======
 - TwitchIO
@@ -56,7 +60,7 @@ Master
     - Bug fixes
         - Add type conversion for variable positional arguments
         - Fixed message content while handling commands in reply messages
-      
+
 - ext.pubsub
     - Bug fixes
         - :class:`~twitchio.ext.pubsub.PubSubModerationAction` now handles missing keys

--- a/twitchio/ext/sounds/__init__.py
+++ b/twitchio/ext/sounds/__init__.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 AP = TypeVar("AP", bound="AudioPlayer")
 
-ffmpeg_bin: str = None
+ffmpeg_bin: Optional[str] = None
 try:
     proc = subprocess.Popen(["ffmpeg", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except FileNotFoundError:

--- a/twitchio/ext/sounds/__init__.py
+++ b/twitchio/ext/sounds/__init__.py
@@ -45,9 +45,7 @@ AP = TypeVar("AP", bound="AudioPlayer")
 
 ffmpeg_bin: str = None
 try:
-    proc = subprocess.Popen(
-        ["ffmpeg", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
+    proc = subprocess.Popen(["ffmpeg", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 except FileNotFoundError:
     try:
         proc = subprocess.Popen(["ffmpeg.exe", "-version"])
@@ -146,9 +144,7 @@ class Sound:
         self.proc = None
 
         if ffmpeg_bin is None:
-            raise RuntimeError(
-                "ffmpeg is required to create and play Sounds. Check your is present in your Path"
-            )
+            raise RuntimeError("ffmpeg is required to create and play Sounds. Check your is present in your Path")
 
         if info:
             self.proc = subprocess.Popen(
@@ -197,9 +193,7 @@ class Sound:
         self._rate = 48000
 
     @classmethod
-    async def ytdl_search(
-        cls, search: str, *, loop: Optional[asyncio.BaseEventLoop] = None
-    ):
+    async def ytdl_search(cls, search: str, *, loop: Optional[asyncio.BaseEventLoop] = None):
         """|coro|
 
         Search songs via YouTube ready to be played.
@@ -304,9 +298,7 @@ class AudioPlayer:
         elif self._playing and not replace:
             return
 
-        self._thread = threading.Thread(
-            target=self._play_run, args=([sound]), daemon=True
-        )
+        self._thread = threading.Thread(target=self._play_run, args=([sound]), daemon=True)
         self._thread.start()
 
     def _play_run(self, sound: Sound):
@@ -412,9 +404,7 @@ class AudioPlayer:
     @active_device.setter
     def active_device(self, device: OutputDevice) -> None:
         if not isinstance(device, OutputDevice):
-            raise TypeError(
-                f"Parameter <device> must be of type <{type(OutputDevice)}> not <{type(device)}>."
-            )
+            raise TypeError(f"Parameter <device> must be of type <{type(OutputDevice)}> not <{type(device)}>.")
 
         self._use_device = device
         if not self._stream:
@@ -434,9 +424,7 @@ class AudioPlayer:
         self._paused = False
 
     @classmethod
-    def with_device(
-        cls, *, callback: Callable[..., Coroutine[Any, Any, None]], device: OutputDevice
-    ) -> AP:
+    def with_device(cls, *, callback: Callable[..., Coroutine[Any, Any, None]], device: OutputDevice) -> AP:
         """Method which returns a player ready to be used with the given :class:`OutputDevice`.
 
         Returns
@@ -444,9 +432,7 @@ class AudioPlayer:
             :class:`OutputDevice`
         """
         if not isinstance(device, OutputDevice):
-            raise TypeError(
-                f"Parameter <device> must be of type <{type(OutputDevice)}> not <{type(device)}>."
-            )
+            raise TypeError(f"Parameter <device> must be of type <{type(OutputDevice)}> not <{type(device)}>.")
 
         self = cls(callback=callback)
         self._use_device = device


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

Hello all, first thank for work on twitchIO,

## Pull request summary

I just see a small error in this extension, on my fedora (python 3.10) the sound extension not work properly, ffmpeg detection does not work. 

This call will fail even if `ffmpeg` is present in PATH:
```
proc = subprocess.Popen("ffmpeg -version", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
```

This code also fix the error:
```
proc = subprocess.Popen(["ffmpeg", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
```

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)