### PR TITLE
Fix unsubscribe/subscribe of Pubsub + enhance pubsub websocket

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,11 @@ Master
 - ext.commands
     - Bug fixes
         - Make sure double-quotes are properly tokenized for bot commands
+        
+- ext.pubsub
+    - Bug fixes      
+        - Unsubscribing from Pubsubevents works again
+        - Websocket automatically handles "RECONNECT" requests by Twitch
 
 - ext.eventsub
     - Additions

--- a/twitchio/ext/pubsub/pool.py
+++ b/twitchio/ext/pubsub/pool.py
@@ -66,6 +66,7 @@ class PubSubPool:
         if node is None:
             node = PubSubWebsocket(self.client, max_topics=self._max_connection_topics)
             await node.connect()
+            self._pool.append(node)
 
         await node.subscribe_topics(topics)
         self._topics.update({t: node for t in topics})
@@ -81,7 +82,7 @@ class PubSubPool:
 
         """
         for node, vals in itertools.groupby(topics, lambda t: self._topics[t]):
-            await node.unsubscribe_topic(vals)
+            await node.unsubscribe_topic(list(vals))
             if not node.topics:
                 await node.disconnect()
                 self._pool.remove(node)

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -194,6 +194,9 @@ class PubSubWebsocket:
         if message["error"]:
             logger.error(f"Received errored response for nonce {message['nonce']}: {message['error']}")
             self.client.run_event("pubsub_error", message)
+        elif message["type"] == "RECONNECT":
+            logger.warning("Received RECONNECT response from pubsub edge. Reconnecting")
+            await asyncio.shield(self.reconnect())
         elif message["nonce"]:
             logger.debug(f"Received OK response for nonce {message['nonce']}")
             self.client.run_event("pubsub_nonce", message)


### PR DESCRIPTION
## Pull request summary

- Adds missing append in `subscribe_topics` (never filled its own _pool List)

- Fixes unsubscribing from Pubsub by changing the type passed to `unsubscribe_topic` in the websocket from groupby to list, because we iterate in `_send_topics` again. Iterating over an groupby objects results in an empty list. 

- Pubsub Websocket handles now `RECONNECT` messages accordingly.


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)