### PR TITLE
Replacing HypeTrainBeginProgressData class with HypeTrainBeginData and HypeTrainProgressData

### DIFF
--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -172,11 +172,11 @@ This is a list of events dispatched by the eventsub ext.
 
     Called when someone ends a goal on their channel.
 
-.. function:: event_eventsub_notification_hypetrain_begin(event: HypeTrainBeginProgressData)
+.. function:: event_eventsub_notification_hypetrain_begin(event: HypeTrainBeginData)
 
     Called when a hype train starts on their channel.
 
-.. function:: event_eventsub_notification_hypetrain_progress(event: HypeTrainBeginProgressData)
+.. function:: event_eventsub_notification_hypetrain_progress(event: HypeTrainProgressData)
 
     Called when a hype train receives an update on their channel.
 
@@ -295,9 +295,15 @@ API Reference
     :members:
     :inherited-members:
 
-.. attributetable::: HypeTrainBeginProgressData
+.. attributetable::: HypeTrainBeginData
 
-.. autoclass:: HypeTrainBeginProgressData
+.. autoclass:: HypeTrainBeginData
+    :members:
+    :inherited-members:
+
+.. attributetable::: HypeTrainProgressData
+
+.. autoclass:: HypeTrainProgressData
     :members:
     :inherited-members:
 

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -634,9 +634,9 @@ class HypeTrainContributor:
         self.total: int = data["total"]
 
 
-class HypeTrainBeginProgressData(EventData):
+class HypeTrainBeginData(EventData):
     """
-    A Hype Train Begin/Progress event
+    A Hype Train Begin event
 
     Attributes
     -----------
@@ -672,6 +672,57 @@ class HypeTrainBeginProgressData(EventData):
 
     def __init__(self, client: EventSubClient, data: dict):
         self.broadcaster = _transform_user(client, data, "broadcaster_user")
+        self.total_points: int = data["total"]
+        self.progress: int = data["progress"]
+        self.goal: int = data["goal"]
+        self.started = _parse_datetime(data["started_at"])
+        self.expires = _parse_datetime(data["expires_at"])
+        self.top_contributions = [HypeTrainContributor(client, d) for d in data["top_contributions"]]
+        self.last_contribution = HypeTrainContributor(client, data["last_contribution"])
+
+
+class HypeTrainProgressData(EventData):
+    """
+    A Hype Train Progress event
+
+    Attributes
+    -----------
+
+    broadcaster: :class:`twitchio.PartialUser`
+        The channel the Hype Train occurred in
+    total_points: :class:`int`
+        The total amounts of points in the Hype Train
+    level: :class:'int'
+        The current level of the Hype Train
+    progress: :class:`int`
+        The progress of the Hype Train towards the next level
+    goal: :class:`int`
+        The goal to reach the next level
+    started: :class:`datetime.datetime`
+        When the Hype Train started
+    expires: :class:`datetime.datetime`
+        When the Hype Train ends
+    top_contributions: List[:class:`HypeTrainContributor`]
+        The top contributions of the Hype Train
+    last_contribution: :class:`HypeTrainContributor`
+        The last contributor to the Hype Train
+    """
+
+    __slots__ = (
+        "broadcaster",
+        "total_points",
+        "level",
+        "progress",
+        "goal",
+        "top_contributions",
+        "last_contribution",
+        "started",
+        "expires",
+    )
+
+    def __init__(self, client: EventSubClient, data: dict):
+        self.broadcaster = _transform_user(client, data, "broadcaster_user")
+        self.level: int = data["level"]
         self.total_points: int = data["total"]
         self.progress: int = data["progress"]
         self.goal: int = data["goal"]
@@ -1281,7 +1332,8 @@ _DataType = Union[
     ChannelGoalEndData,
     CustomRewardAddUpdateRemoveData,
     CustomRewardRedemptionAddUpdateData,
-    HypeTrainBeginProgressData,
+    HypeTrainBeginData,
+    HypeTrainProgressData,
     HypeTrainEndData,
     PollBeginProgressData,
     PollEndData,
@@ -1336,8 +1388,8 @@ class _SubscriptionTypes(metaclass=_SubTypesMeta):
     channel_goal_progress = "channel.goal.progress", 1, ChannelGoalBeginProgressData
     channel_goal_end = "channel.goal.end", 1, ChannelGoalEndData
 
-    hypetrain_begin = "channel.hype_train.begin", 1, HypeTrainBeginProgressData
-    hypetrain_progress = "channel.hype_train.progress", 1, HypeTrainBeginProgressData
+    hypetrain_begin = "channel.hype_train.begin", 1, HypeTrainBeginData
+    hypetrain_progress = "channel.hype_train.progress", 1, HypeTrainProgressData
     hypetrain_end = "channel.hype_train.end", 1, HypeTrainEndData
 
     poll_begin = "channel.poll.begin", 1, PollBeginProgressData


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary
The pull request replaces the HypeTrainBeginProgressData class with HypeTrainBeginData and HypeTrainProgressData as Hype Train Progress events also have a Level attribute inside their responses while Hype Train Begin events don't
<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)