### PR TITLE
fix a forgotten nonce

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Master
         - Websocket automatically handles "RECONNECT" requests by Twitch
     - Bug fixes      
         - Unsubscribing from Pubsubevents works again
-
+        - Fix a forgotten nonce in :func:`~twitchio.ext.pubsub.websocket._send_topics`
 
 
 - ext.sound

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -119,7 +119,11 @@ class PubSubWebsocket:
     async def _send_topics(self, topics: List[Topic], type="LISTEN"):
         for tok, _topics in groupby(topics, key=lambda val: val.token):
             nonce = ("%032x" % uuid.uuid4().int)[:8]
-            payload = {"type": type, "nonce": nonce, "data": {"topics": [x.present for x in _topics], "auth_token": tok}}
+            payload = {
+                "type": type,
+                "nonce": nonce,
+                "data": {"topics": [x.present for x in _topics], "auth_token": tok},
+            }
             logger.debug(f"Sending {type} payload with nonce '{nonce}': {payload}")
             await self.send(payload)
 

--- a/twitchio/ext/pubsub/websocket.py
+++ b/twitchio/ext/pubsub/websocket.py
@@ -119,7 +119,7 @@ class PubSubWebsocket:
     async def _send_topics(self, topics: List[Topic], type="LISTEN"):
         for tok, _topics in groupby(topics, key=lambda val: val.token):
             nonce = ("%032x" % uuid.uuid4().int)[:8]
-            payload = {"type": type, "data": {"topics": [x.present for x in _topics], "auth_token": tok}}
+            payload = {"type": type, "nonce": nonce, "data": {"topics": [x.present for x in _topics], "auth_token": tok}}
             logger.debug(f"Sending {type} payload with nonce '{nonce}': {payload}")
             await self.send(payload)
 


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

After we subscribe to topics we wait for the `event_pubsub_nonce`, but it is not called because the server does not pass the nonce it should return in response to the client, which we wait for in `websocket.py:200`

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)