### PR TITLE
Add `first` to Message class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Master
 ======
 - TwitchIO
     - Additions
+        - Added :attr:`~twitchio.Message.first` to :class:`~twitchio.Message`
         - Added :func:`~twitchio.PartialUser.fetch_channel_emotes` to :class:`~twitchio.PartialUser`
         - Added :func:`~twitchio.Client.fetch_global_emotes` to :class:`~twitchio.Client`
         - Added :func:`~twitchio.Client.event_channel_join_failure` event:

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -64,14 +64,11 @@ class Message:
         self._tags = kwargs.get("tags")
         self.echo = kwargs.get("echo", False)
 
+        self.first = False
         if self._tags is not None:
             first = self._tags.get("first-msg")
             if first == "1":
                 self.first = True
-            else:
-                self.first = False
-        else:
-            self.first = False
 
         try:
             self._id = self._tags["id"]

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -68,7 +68,7 @@ class Message:
             first = self._tags.get("first-msg")
             if self.first == "1":
                 self.first = True
-            elif self.first == "0":
+            else:
                 self.first = False
         else:
             self.first = None

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -66,7 +66,7 @@ class Message:
 
         if self._tags is not None:
             first = self._tags.get("first-msg")
-            if self.first == "1":
+            if first == "1":
                 self.first = True
             else:
                 self.first = False

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -71,7 +71,7 @@ class Message:
             else:
                 self.first = False
         else:
-            self.first = None
+            self.first = False
 
         try:
             self._id = self._tags["id"]

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -39,6 +39,8 @@ class Message:
         The content of this message.
     echo: :class:`bool`
         Boolean representing if this is a self-message or not.
+    first: :class:`bool`
+        Boolean representing whether it's a first message or not. Could be None.
 
     """
 
@@ -47,6 +49,7 @@ class Message:
         "content",
         "_author",
         "echo",
+        "first",
         "_timestamp",
         "_channel",
         "_tags",
@@ -60,6 +63,15 @@ class Message:
         self._channel = kwargs.get("channel")
         self._tags = kwargs.get("tags")
         self.echo = kwargs.get("echo", False)
+
+        if self._tags is not None:
+            self.first = self._tags.get("first-msg")
+            if self.first == "1":
+                self.first = True
+            elif self.first == "0":
+                self.first = False
+        else:
+            self.first = None
 
         try:
             self._id = self._tags["id"]

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -40,7 +40,7 @@ class Message:
     echo: :class:`bool`
         Boolean representing if this is a self-message or not.
     first: :class:`bool`
-        Boolean representing whether it's a first message or not. Could be None.
+        Boolean representing whether it's a first message or not.
 
     """
 

--- a/twitchio/message.py
+++ b/twitchio/message.py
@@ -65,7 +65,7 @@ class Message:
         self.echo = kwargs.get("echo", False)
 
         if self._tags is not None:
-            self.first = self._tags.get("first-msg")
+            first = self._tags.get("first-msg")
             if self.first == "1":
                 self.first = True
             elif self.first == "0":


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
Add `first` to Message class.

I just added `first` attr to Message that using `first-msg` tag, and updated `changelog.rst`.

Maybe it's about [this](https://github.com/TwitchIO/TwitchIO/discussions/313) discussion.

I've tested to connecte some channel with a bot and chated something. Message.first worked well I think.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)