### PR TITLE
Change revokation to revocation.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,4 +1,4 @@
-:orphan:     
+:orphan:
 
 
 Master
@@ -30,11 +30,11 @@ Master
 - ext.commands
     - Bug fixes
         - Make sure double-quotes are properly tokenized for bot commands
-        
+
 - ext.pubsub
     - Additions
         - Websocket automatically handles "RECONNECT" requests by Twitch
-    - Bug fixes      
+    - Bug fixes
         - Unsubscribing from Pubsubevents works again
         - Fix a forgotten nonce in :func:`~twitchio.ext.pubsub.websocket._send_topics`
 
@@ -53,10 +53,11 @@ Master
             - :func:`~twitchio.ext.eventsub.event_eventsub_notification_channel_goal_end`
 
     - Bug fixes
-        Correct typo in :class:`~twitchio.ext.eventsub.HypeTrainBeginProgressData` attribute :attr:`~twitchio.ext.eventsub.HypeTrainBeginProgressData.expires`
-        
+        - Correct typo in :class:`~twitchio.ext.eventsub.HypeTrainBeginProgressData` attribute :attr:`~twitchio.ext.eventsub.HypeTrainBeginProgressData.expires`
+        - Correct typo "revokation" to "revocation" in server _message_types.
+
 - ext.pubsub
-    - Bug fixes      
+    - Bug fixes
         - "type" of :class:`~twitchio.ext.pubsub.PubSubModerationActionChannelTerms` now uses the correct type data
 
 

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("twitchio.ext.eventsub")
 _message_types = {
     "webhook_callback_verification": models.ChallengeEvent,
     "notification": models.NotificationEvent,
-    "revokation": models.RevokationEvent,
+    "revocation": models.RevokationEvent,
 }
 
 
@@ -234,7 +234,7 @@ class EventSubClient(web.Application):
             self.client.run_event(
                 f"eventsub_notification_{models.SubscriptionTypes._name_map[event.subscription.type]}", event
             )
-        elif typ == "revokation":
+        elif typ == "revocation":
             self.client.run_event("eventsub_revokation", event)
 
         return response


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

"Revokation" is a typo and does not match the message type "revocation" that Twitch uses. I do not have the means to test this at the moment, though I have implemented this fix successfully in a modified version of this library. I don't see reference to this in the documentation, so I don't think that needs updated. There are other uses of "revokation", though fixing them would fall into the category of a breaking change, so I left them alone for now.

Reference: https://dev.twitch.tv/docs/eventsub/handling-webhook-events

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)