### PR TITLE
Propagate authentication errors to end user when calling run()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Master
             - This is dispatched when the bot fails to join a channel
             - This also makes the channel join error message in logs optional
     - Bug fixes
+        - Fix AuthenticationError not being properly propagated when a bad token is given
         - Fix channel join failures causing `ValueError: list.remove(x): x not in list` when joining channels after the initial start
         - Added :attr:`~twitchio.Chatter.is_vip` property to Chatter
         - New PartialUser methods

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -30,7 +30,7 @@ import traceback
 import sys
 from typing import Union, Callable, List, Optional, Tuple, Any, Coroutine, Dict
 
-from twitchio.errors import HTTPException
+from twitchio.errors import HTTPException, AuthenticationError
 from . import models
 from .websocket import WSConnection
 from .http import TwitchHTTP
@@ -155,7 +155,8 @@ class Client:
         connects to the twitch IRC server, and cleans up when done.
         """
         try:
-            self.loop.create_task(self.connect())
+            task = self.loop.create_task(self.connect())
+            self.loop.run_until_complete(task) # this'll raise if the connect fails
             self.loop.run_forever()
         except KeyboardInterrupt:
             pass

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -156,7 +156,7 @@ class Client:
         """
         try:
             task = self.loop.create_task(self.connect())
-            self.loop.run_until_complete(task) # this'll raise if the connect fails
+            self.loop.run_until_complete(task)  # this'll raise if the connect fails
             self.loop.run_forever()
         except KeyboardInterrupt:
             pass

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -126,7 +126,7 @@ class WSConnection:
                 data = await self._client._http.validate(token=self._token)
             except AuthenticationError:
                 await self._client._http.session.close()
-                self._client._closing.set() # clean up and error out (this is called to avoid calling Client.close in start()
+                self._client._closing.set()  # clean up and error out (this is called to avoid calling Client.close in start()
                 raise
             self.nick = data["login"]
             self.user_id = int(data["user_id"])

--- a/twitchio/websocket.py
+++ b/twitchio/websocket.py
@@ -122,7 +122,12 @@ class WSConnection:
         if self.is_alive:
             await self._websocket.close()  # If for some reason we are in a weird state, close it before retrying.
         if not self._client._http.nick:
-            data = await self._client._http.validate(token=self._token)
+            try:
+                data = await self._client._http.validate(token=self._token)
+            except AuthenticationError:
+                await self._client._http.session.close()
+                self._client._closing.set() # clean up and error out (this is called to avoid calling Client.close in start()
+                raise
             self.nick = data["login"]
             self.user_id = int(data["user_id"])
         else:


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
Opening this as a PR in case of adverse side effects before merging. Will merge in 1-2 days after some additional testing.

Previously AuthenticationError being raised would go unhandled, because run calls `create_task(connect)` and ignored the output/error. This also removes a wrapping error when calling start with a bad token.
This fixes #344 

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)