### PR TITLE
Fix an exception when calling User.fetch_bits_leaderboard method without started_at argument

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Master
     - Additions
         - Added optional ``started_at`` and ``ended_at`` arguments to :func:`~twitchio.PartialUser.fetch_clips`
         - Updated docstring regarding new  HypeTrain contribution  method ``OTHER`` for :attr:`~twitchio.HypeTrainContribution.type`
+    - Bug fixes
+        - Fix an issue when using the method `User.fetch_bits_leaderboard` without the `started_at` argument.
 - ext.eventsub
     - Additions
         - Updated docs regarding new HypeTrain contribution method ``other`` for :attr:`~twitchio.ext.eventsub.HypeTrainContributor.type`

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -58,6 +58,10 @@ class Route:
         headers: dict = None,
         token: str = None,
     ):
+        # Remove None parameters from query parameters
+        if query is not None:
+            query = [x for x in query if (x is not None) and (x[1] is not None)]
+
         self.headers = headers or {}
         self.method = method
         self.query = query
@@ -564,9 +568,8 @@ class TwitchHTTP:
         ]
         if ids:
             q.extend(("id", id) for id in ids)
-        query = [x for x in q if x[1] is not None]
 
-        return await self.request(Route("GET", "clips", query=query, token=token))
+        return await self.request(Route("GET", "clips", query=q, token=token))
 
     async def post_entitlements_upload(self, manifest_id: str, type="bulk_drops_grant"):
         return await self.request(

--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -97,8 +97,12 @@ class BitsLeaderboard:
 
     def __init__(self, http: "TwitchHTTP", data: dict):
         self._http = http
-        self.started_at = datetime.datetime.fromisoformat(data["date_range"]["started_at"])
-        self.ended_at = datetime.datetime.fromisoformat(data["date_range"]["ended_at"])
+
+        started_at_raw = data["date_range"]["started_at"]
+        ended_at_raw = data["date_range"]["started_at"]
+
+        self.started_at = datetime.datetime.fromisoformat(started_at_raw) if started_at_raw else None
+        self.ended_at = datetime.datetime.fromisoformat(ended_at_raw) if ended_at_raw else None
         self.leaders = [BitLeaderboardUser(http, x) for x in data["data"]]
 
     def __repr__(self):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

When calling "User.fetch_bits_leaderboard", the following error was raised:

> Traceback (most recent call last):
>   File "\TwitchIO\test.py", line 60, in <module>
>     asyncio.run(main())
>   File "\Python39\lib\asyncio\runners.py", line 44, in run
>     return loop.run_until_complete(main)
>   File "\Python39\lib\asyncio\base_events.py", line 647, in run_until_complete
>     return future.result()
>   File "\TwitchIO\test.py", line 32, in main
>     print("therealgraille.fetch_bits_leaderboard:", await therealgraille.fetch_bits_leaderboard(token=TOKEN))
>   File "\TwitchIO\twitchio\user.py", line 283, in fetch_bits_leaderboard
>     data = await self._http.get_bits_board(token, period, user_id, started_at)
>   File "\TwitchIO\twitchio\http.py", line 321, in get_bits_board
>     route = Route(
>   File "\TwitchIO\twitchio\http.py", line 72, in __init__
>     self.path = self.path.with_query(query)
>   File "\Python39\lib\site-packages\yarl\_url.py", line 977, in with_query
>     new_query = self._get_str_query(*args, **kwargs)
>   File "\Python39\lib\site-packages\yarl\_url.py", line 951, in _get_str_query
>     query = "&".join(
>   File "\Python39\lib\site-packages\yarl\_url.py", line 952, in <genexpr>
>     quoter(k) + "=" + quoter(self._query_var(v)) for k, v in query
>   File "\Python39\lib\site-packages\yarl\_url.py", line 916, in _query_var
>     raise TypeError(
> TypeError: Invalid variable type: value should be str, int or float, got None of type <class 'NoneType'>

This was because the query contained some None values (`started_at`parameter wasn't specified) :

```python
async def get_bits_board(
    self, token: str, period: str = "all", user_id: str = None, started_at: datetime.datetime = None
):
    assert period in {"all", "day", "week", "month", "year"}
    route = Route(
        "GET",
        "bits/leaderboard",
        "",
        query=[
            ("period", period),
            ("started_at", started_at.isoformat() if started_at else None), # <--- HERE
            ("user_id", user_id),
        ],
        token=token,
    )
    return await self.request(route, full_body=True, paginate=False)
```

the same thing happen in `get_clips()`, but `get_clips()` add a step to eliminate the None values, which `get_bits_board()` doesn't :

```python
query = [x for x in q if x[1] is not None]
```

To generalize this, I removed this line from `get_clips()` and add a check of entire query in Route class. This fix the issue.

After this fix, another Exception was raised:

> Traceback (most recent call last):
>   File "\TwitchIO\test.py", line 60, in <module>
>     asyncio.run(main())
>   File "\Python39\lib\asyncio\runners.py", line 44, in run
>     return loop.run_until_complete(main)
>   File "\Python39\lib\asyncio\base_events.py", line 647, in run_until_complete
>     return future.result()
>   File "\TwitchIO\test.py", line 32, in main
>     print("therealgraille.fetch_bits_leaderboard:", await therealgraille.fetch_bits_leaderboard(token=TOKEN))
>   File "\TwitchIO\twitchio\user.py", line 284, in fetch_bits_leaderboard
>     return BitsLeaderboard(self._http, data)
>   File "\TwitchIO\twitchio\models.py", line 100, in __init__
>     self.started_at = datetime.datetime.fromisoformat(data["date_range"]["started_at"])
> ValueError: Invalid isoformat string: ''

This error appears when the result of the request is empty (especialy the values of `started_at` and `ended_at` in the server response). I added a condition to check when it happens.


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [X] I have updated the changelog with a quick recap of my changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)