### PR TITLE
Fix parsing of ScheduleSegments with no end time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Master
 
     - Bug fixes
         - Fix :func:`~twitchio.PartialUser.fetch_bits_leaderboard` not handling ``started_at`` and :class:`~twitchio.BitsLeaderboard` not correctly parsing
+        - Fix parsing ScheduleSegments where end_time is None
 
 - ext.eventsub
     - Additions

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ Master
 
     - Bug fixes
         - Fix :func:`~twitchio.PartialUser.fetch_bits_leaderboard` not handling ``started_at`` and :class:`~twitchio.BitsLeaderboard` not correctly parsing
-        - Fix parsing ScheduleSegments where end_time is None
+        - Fix parsing :class:`~twitchio.ScheduleSegment` where :attr:`~twitchio.ScheduleSegment.end_time` is None
 
 - ext.eventsub
     - Additions

--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -1279,7 +1279,7 @@ class ScheduleSegment:
     def __init__(self, data: dict):
         self.id: str = data["id"]
         self.start_time = parse_timestamp(data["start_time"])
-        self.end_time = parse_timestamp(data["end_time"])
+        self.end_time = parse_timestamp(data["end_time"]) if data["end_time"] else None
         self.title: str = data["title"]
         self.canceled_until = parse_timestamp(data["canceled_until"]) if data["canceled_until"] else None
         self.category = ScheduleCategory(data["category"]) if data["category"] else None

--- a/twitchio/models.py
+++ b/twitchio/models.py
@@ -1262,7 +1262,7 @@ class ScheduleSegment:
         The ID for the scheduled broadcast.
     start_time: :class:`datetime.datetime`
         Scheduled start time for the scheduled broadcast
-    end_time: :class:`datetime.datetime`
+    end_time: Optional[:class:`datetime.datetime`]
         Scheduled end time for the scheduled broadcast
     title: :class:`str`
         Title for the scheduled broadcast.


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
When a Schedule Segment had an end time of `None`, it could not get parsed.

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)