### PR TITLE
Add support for type and user_id queries on get_subscriptions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,7 +27,7 @@ Master
         - Added Shield Status events
             - :func:`~twitchio.ext.eventsub.EventSubClient.subscribe_channel_shield_mode_begin`
             - :func:`~twitchio.ext.eventsub.EventSubClient.subscribe_channel_shield_mode_end`
-        - Added support for `type` and `user_id` queries on :func:`~twitchio.ext.eventsub.EventSubClient.get_subscriptions`
+        - Added support for ``type`` and ``user_id`` queries on :func:`~twitchio.ext.eventsub.EventSubClient.get_subscriptions`
 
 2.5.0
 ======

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Master
         - Added Shield Status events
             - :func:`~twitchio.ext.eventsub.EventSubClient.subscribe_channel_shield_mode_begin`
             - :func:`~twitchio.ext.eventsub.EventSubClient.subscribe_channel_shield_mode_end`
+        - Added support for `type` and `user_id` queries on :func:`~twitchio.ext.eventsub.EventSubClient.get_subscriptions`
 
 2.5.0
 ======

--- a/twitchio/ext/eventsub/http.py
+++ b/twitchio/ext/eventsub/http.py
@@ -36,10 +36,14 @@ class EventSubHTTP:
             Route("DELETE", "eventsub/subscriptions", query=[("id", subscription)]), paginate=False
         )
 
-    async def get_subscriptions(self, status: str = None):
+    async def get_subscriptions(self, status: str = None, sub_type: str = None, user_id: str = None):
         qs = []
         if status:
             qs.append(("status", status))
+        if sub_type:
+            qs.append(("type", sub_type))
+        if user_id:
+            qs.append(("user_id", user_id))
 
         return [
             models.Subscription(d)

--- a/twitchio/ext/eventsub/http.py
+++ b/twitchio/ext/eventsub/http.py
@@ -36,14 +36,18 @@ class EventSubHTTP:
             Route("DELETE", "eventsub/subscriptions", query=[("id", subscription)]), paginate=False
         )
 
-    async def get_subscriptions(self, status: str = None, sub_type: str = None, user_id: str = None):
+    async def get_subscriptions(
+        self, status: Optional[str] = None, sub_type: Optional[str] = None, user_id: Optional[int] = None
+    ):
         qs = []
         if status:
             qs.append(("status", status))
         if sub_type:
             qs.append(("type", sub_type))
         if user_id:
-            qs.append(("user_id", user_id))
+            qs.append(("user_id", str(user_id)))
+        if len(qs) > 1:
+            raise ValueError("You cannot specify more than one filter.")
 
         return [
             models.Subscription(d)

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -52,7 +52,9 @@ class EventSubClient(web.Application):
         for subscription_id in active_subscriptions:
             await self.delete_subscription(subscription_id)
 
-    async def get_subscriptions(self, status: str = None, sub_type: str = None, user_id: str = None):
+    async def get_subscriptions(
+        self, status: Optional[str] = None, sub_type: Optional[str] = None, user_id: Optional[int] = None
+    ):
         # All possible statuses are:
         #
         #     enabled: designates that the subscription is in an operable state and is valid.

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -52,7 +52,7 @@ class EventSubClient(web.Application):
         for subscription_id in active_subscriptions:
             await self.delete_subscription(subscription_id)
 
-    async def get_subscriptions(self, status: str = None):
+    async def get_subscriptions(self, status: str = None, sub_type: str = None, user_id: str = None):
         # All possible statuses are:
         #
         #     enabled: designates that the subscription is in an operable state and is valid.
@@ -61,7 +61,7 @@ class EventSubClient(web.Application):
         #     notification_failures_exceeded: notification delivery failure rate was too high.
         #     authorization_revoked: authorization for user(s) in the condition was revoked.
         #     user_removed: a user in the condition of the subscription was removed.
-        return await self._http.get_subscriptions(status)
+        return await self._http.get_subscriptions(status, sub_type, user_id)
 
     async def subscribe_user_updated(self, user: Union[PartialUser, str, int]):
         if isinstance(user, PartialUser):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

This PR adds support for `type` and `user_id` queries to EventSub get_subscriptions.
https://dev.twitch.tv/docs/api/reference/#get-eventsub-subscriptions

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)