### PR TITLE
Fix incorrect hyperlink format

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@
    Consider joining the Official Discord server for a fast response to help.<br>
    <a href="https://discord.gg/RAKc3HF"><img src="https://discordapp.com/api/guilds/490948346773635102/widget.png?style=banner2"></a><br><br>
 
-   <b>For issues and contributing with the library, visit:</b> <a href"https://github.com/TwitchIO/TwitchIO">GitHub</a>
+   <b>For issues and contributing with the library, visit:</b> <a href="https://github.com/TwitchIO/TwitchIO">GitHub</a>
 
 
 .. rst-class:: index-display-none


### PR DESCRIPTION
I have added the missing "://" in the href and tested the hyperlink to ensure that it now correctly points to the project's GitHub page.