### PR TITLE
HypeTrain return empty shared_train_participants list if not shared_train

### DIFF
--- a/docs/getting-started/changelog.rst
+++ b/docs/getting-started/changelog.rst
@@ -37,6 +37,7 @@ Changelog
         - Fix some typing issues with adapters in :class:`~twitchio.Client`.
         - Fixed a bug causing conduit websockets to be treated as eventsub websockets and fail after a reconnect attempt.
         - Fixed incorrect documentation in :func:`~twitchio.PartialUser.fetch_moderators`.
+        - Fix :class:`~models.eventsub_.BaseHypeTrain` now returns empty list for shared_train_participants if not shared_train.
 
 
 3.1.0

--- a/twitchio/models/eventsub_.py
+++ b/twitchio/models/eventsub_.py
@@ -4957,11 +4957,15 @@ class BaseHypeTrain(_ResponderEvent):
             HypeTrainContribution(c, http=http) for c in payload["top_contributions"]
         ]
         self.started_at: datetime.datetime = parse_timestamp(payload["started_at"])
-        self.shared_train_participants: list[PartialUser] = [
-            PartialUser(u["broadcaster_user_id"], u["broadcaster_user_login"], u["broadcaster_user_name"], http=http)
-            for u in payload["shared_train_participants"]
-        ]
         self.shared_train: bool = bool(payload["is_shared_train"])
+        self.shared_train_participants: list[PartialUser] = (
+            [
+                PartialUser(u["broadcaster_user_id"], u["broadcaster_user_login"], u["broadcaster_user_name"], http=http)
+                for u in payload["shared_train_participants"]
+            ]
+            if self.shared_train
+            else []
+        )
         self.type: Literal["treasure", "golden_kappa", "regular"] = payload["type"]
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Description

Small fix to fix to resolve TypeError for all hype train events. If not a shared train, return empty list for shared_train_participants.
Problem in BaseHypeTrain causes the same error for hype train begin, progress and end due to 'shared_train_participants' in event being None.

```
File "/twitchio/models/eventsub_.py", line 4960, in __init__
    self.shared_train_participants: list[PartialUser] = [
                                                        ^
TypeError: 'NoneType' object is not iterable
```

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
