### PR TITLE
Allow stacking routine decorators

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -3306,7 +3306,7 @@ class AutoClient(Client):
     multiple channels/broadcasters *or* requires subscription continuity.
 
     Twitch Conduits are a method of EventSub transport which allow higher throughput of events, higher
-    (essentially unlimited) subscription limts (within cost), continutiy of subscriptions and scaling.
+    (essentially unlimited) subscription limts (within cost), continuity of subscriptions and scaling.
 
     To benefit from the subscription continuity of Conduits, your application is expected to have been connected to the
     associated Conduit within ``72 hours`` of it going offline.

--- a/twitchio/ext/routines/__init__.py
+++ b/twitchio/ext/routines/__init__.py
@@ -370,6 +370,7 @@ class Routine:
             LOGGER.warning("The before_routine for %s has previously been set.", self.__repr__())
 
         self._before_routine = func
+        return func
 
     def after_routine(self, func: CoroT) -> None:
         """|deco|
@@ -385,6 +386,7 @@ class Routine:
             LOGGER.warning("The after_routine for %s has previously been set.", self.__repr__())
 
         self._after_routine = func
+        return func
 
     async def on_error(self, error: Exception) -> None:
         """|coro|
@@ -410,6 +412,7 @@ class Routine:
             raise TypeError(f'"error" for {self!r} expected a coroutine function not {type(func).__name__!r}')
 
         self._on_error = func
+        return func
 
     @property
     def completed_iterations(self) -> int:


### PR DESCRIPTION
This simple PR allows stacking multiple decorators on the same coroutine.
E.g. you have two routines (send_alert, send_reminder). This allows using:
```
@send_alert.before_routine
@send_reminder.before_routine
async def before_sending():
    ...
```
- Add return func statement to routine decorators