### PR TITLE
fix: Fix SearchChannel model missing game_name field mapping

### DIFF
--- a/twitchio/models/search.py
+++ b/twitchio/models/search.py
@@ -73,6 +73,7 @@ class SearchChannel:
         "_http",
         "broadcaster",
         "game_id",
+        "game_name",
         "language",
         "live",
         "name",
@@ -86,6 +87,7 @@ class SearchChannel:
         self._http: HTTPClient = http
         self.broadcaster: PartialUser = PartialUser(data["id"], data["broadcaster_login"], data["display_name"], http=http)
         self.game_id: str = data["game_id"]
+        self.game_name: str = data["game_name"]
         self.title: str = data["title"]
         self.thumbnail: Asset = Asset(data["thumbnail_url"], http=http)
         self.language: str = data["broadcaster_language"]


### PR DESCRIPTION
## Summary

- Adds the missing `game_name` field to the `SearchChannel` model's `__slots__` and `__init__`, so it is properly mapped from the Helix API response.

## Change

```diff
  __slots__ = (
      "_http",
      "broadcaster",
      "game_id",
+     "game_name",
      "language",
      ...
  )

  def __init__(self, data: SearchChannelsResponseData, *, http: HTTPClient) -> None:
      ...
      self.game_id: str = data["game_id"]
+     self.game_name: str = data["game_name"]
      self.title: str = data["title"]
```

The field was already documented in the class docstring and defined in `SearchChannelsResponseData`, but never assigned in the model.

## Reference

- Issue: https://github.com/TwitchIO/TwitchIO/issues/537
- [Twitch Helix Search Channels API](https://dev.twitch.tv/docs/api/reference/#search-channels) — the response includes `game_name`