### PR TITLE
SubscriptionType is missing ChannelCustomPowerUpRedemptionAdd

### DIFF
--- a/twitchio/eventsub/enums.py
+++ b/twitchio/eventsub/enums.py
@@ -99,7 +99,8 @@ class SubscriptionType(enum.Enum):
     ChannelUpdate: Literal["channel.update"]
     ChannelFollow: Literal["channel.follow"]
     ChannelAdBreakBegin: Literal["channel.ad_break.begin"]
-    ChannelBitsUseSubscription: Literal["channel.bits.use"]
+    ChannelBitsUse: Literal["channel.bits.use"]
+    ChannelCustomPowerUpRedemptionAdd: Literal["channel.custom_power_up_redemption.add"]
     ChannelChatClear: Literal["channel.chat.clear"]
     ChannelChatClearUserMessages: Literal["channel.chat.clear_user_messages"]
     ChannelChatMessage: Literal["channel.chat.message"]
@@ -177,6 +178,7 @@ class SubscriptionType(enum.Enum):
     AutomodSettingsUpdate = "automod.settings.update"
     AutomodTermsUpdate = "automod.terms.update"
     ChannelBitsUse = "channel.bits.use"
+    ChannelCustomPowerUpRedemptionAdd = "channel.custom_power_up_redemption.add"
     ChannelUpdate = "channel.update"
     ChannelFollow = "channel.follow"
     ChannelAdBreakBegin = "channel.ad_break.begin"


### PR DESCRIPTION
## Description

`SubscriptionType` is missing the `ChannelCustomPowerUpRedemptionAdd` attribute. This results in a `ValueError` exception.

> ValueError: 'channel.custom_power_up_redemption.add' is not a valid SubscriptionType

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
