### PR TITLE
Fix incorrect id and token_for in CustomRewardRedemption.fulfill

### DIFF
--- a/twitchio/models/channel_points.py
+++ b/twitchio/models/channel_points.py
@@ -435,8 +435,8 @@ class CustomRewardRedemption:
         """
         data = await self._http.patch_custom_reward_redemption(
             broadcaster_id=self.reward.broadcaster.id,
-            id=self.reward.broadcaster.id,
-            token_for=self,
+            id=self.id,
+            token_for=self.reward.broadcaster.id,
             reward_id=self.reward.id,
             status="FULFILLED",
         )


### PR DESCRIPTION
## Description

`CustomRewardRedemption.fulfill()` passes wrong values for two arguments of `patch_custom_reward_redemption`:

```python
id=self.reward.broadcaster.id,   # sends the broadcaster id where the redemption id is expected
token_for=self,                  # sends the redemption object where a user id is expected
```

As a result the call cannot mark a redemption as fulfilled: Helix receives the broadcaster id in the `id` query parameter, and `token_for` gets a `CustomRewardRedemption` instance instead of a user id.

The neighbouring `refund()` already passes both correctly, so this change simply makes `fulfill()` match it:

```diff
-            id=self.reward.broadcaster.id,
-            token_for=self,
+            id=self.id,
+            token_for=self.reward.broadcaster.id,
```

## Reference

- [Twitch Helix Update Redemption Status](https://dev.twitch.tv/docs/api/reference/#update-redemption-status) — `id` is the redemption id, and the request requires a user token for the broadcaster.

## Checklist

- [x] If code changes were made then they have been tested.
    - Running with this patch applied in my own bot, where redemptions are fulfilled on every reward; `fulfill()` works after the change and did not before.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
