### PR TITLE
Fix event typo in `wait_for` docstring

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -918,7 +918,7 @@ class Client:
                 # Only wait for a message sent by "chillymosh"
                 return payload.chatter.name == "chillymosh"
 
-            payload: twitchio.ChatMessage = await client.wait_for("chat_message", predicate=predicate)
+            payload: twitchio.ChatMessage = await client.wait_for("message", predicate=predicate)
             print(f"Chillymosh said: {payload.text}")
 
 


### PR DESCRIPTION
It's supposed to be `message` and not `chat_message`.

<img width="1412" height="89" alt="image" src="https://github.com/user-attachments/assets/c6c95c0e-39ea-4070-a936-24813ba56212" />

Not sure if I should have just sent a screenshot in the discord instead of opening +1-1 PR so sorry if i'm annoying.