### PR TITLE
Fix ChatMessageFragment.gif not exposing gif_id

### DIFF
--- a/twitchio/models/eventsub_.py
+++ b/twitchio/models/eventsub_.py
@@ -1281,7 +1281,7 @@ class ChatMessageFragment:
     ----------
     text: str
         The chat message in plain text.
-    type: typing.Literal["text", "cheermote", "emote", "mention"]
+    type: typing.Literal["text", "cheermote", "emote", "mention", "gif"]
         The type of message fragment. Possible values:
 
         - text
@@ -1296,7 +1296,7 @@ class ChatMessageFragment:
         Cheermote data if a cheermote is sent.
     emote: ChatMessageEmote | None
         Emote data if a cheermote is sent.
-    gif: ChatMessageGifData | None
+    gif: ChatMessageGif | None
         Gif data if a gif is sent.
     """
 
@@ -1314,7 +1314,7 @@ class ChatMessageFragment:
         emote = data.get("emote")
         self.emote: ChatMessageEmote | None = ChatMessageEmote(emote, http=http) if emote else None
         gif: ChatMessageGifData | None = data.get("gif")
-        self.gif: Asset | None = Asset(gif["url"], http=http) if gif else None
+        self.gif: ChatMessageGif | None = ChatMessageGif(gif, http=http) if gif else None
 
     def __repr__(self) -> str:
         return f"<ChatMessageFragment type={self.type} text={self.text}>"


### PR DESCRIPTION
Fixes https://github.com/TwitchIO/TwitchIO/issues/543

## What changed

`ChatMessageFragment.gif` was built as a raw [`Asset`](https://github.com/TwitchIO/TwitchIO/blob/main/twitchio/models/eventsub_.py#L1317) from the payload URL, which discarded `gif_id` and made `fragment.gif.id` raise `AttributeError`. The [`ChatMessageGif`](https://github.com/TwitchIO/TwitchIO/blob/main/twitchio/models/eventsub_.py#L1257) model — added in 3.3.0 specifically to accommodate `ChatMessageFragment.gif` — was never wired in.

Now `ChatMessageFragment.gif` is constructed as a `ChatMessageGif` (matching how `emote`/`cheermote` fragments are handled), exposing:

- `fragment.gif.id` → the GIF's `gif_id`
- `fragment.gif.asset.url` → the GIF URL (same value as before, now nested under `.asset`)

Also fixed the `gif` attribute docstring type (`ChatMessageGifData` → `ChatMessageGif`) and the fragment `type` docstring, which listed the possible values but omitted `gif`.

```python
f = ChatMessageFragment(
    {
        "text": "[some gif]",
        "type": "gif",
        "gif": {
            "gif_id": "joSNxeswxuc74Juo8X",
            "url": "https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif",
        },
    },
    http=None,
)
print(f.gif.id)          # joSNxeswxuc74Juo8X  (was AttributeError)
print(f.gif.asset.url)   # https://media4.giphy.com/media/joSNxeswxuc74Juo8X/giphy.gif
```

## Testing

Verified locally with Python 3.14:

- The repro above now prints `joSNxeswxuc74Juo8X` and the URL (previously `f.gif.id` raised `AttributeError`).
- A fragment without a `gif` key still yields `fragment.gif is None`.
- Emote/cheermote/mention fragments are unaffected (sanity-checked emote parsing).
- `ruff check` and `ruff format --check` (ruff 0.11.2, as pinned in `pyproject.toml`) pass on the changed file.

> [!INFO] *AI disclosure*: This change was prepared with AI assistance on behalf of karlsune and verified locally as described above.